### PR TITLE
[ETFE-687] Call emcs-tfe to retrieve and update UserAnswers instead of public Mongo repo

### DIFF
--- a/.g8/characterCountPage/app/controllers/$className$Controller.scala
+++ b/.g8/characterCountPage/app/controllers/$className$Controller.scala
@@ -8,14 +8,14 @@ import navigation.Navigator
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
+                                       override val userAnswersService: UserAnswersService,
                                        override val navigator: Navigator,
                                        override val auth: AuthAction,
                                        override val withMovement: MovementAction,

--- a/.g8/characterCountPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/characterCountPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -2,22 +2,20 @@ package controllers
 
 import base.SpecBase
 import forms.$className$FormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
-class $className$ControllerSpec extends SpecBase with MockitoSugar {
+class $className$ControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -64,9 +62,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/.g8/checkboxPage/app/controllers/$className$Controller.scala
+++ b/.g8/checkboxPage/app/controllers/$className$Controller.scala
@@ -8,14 +8,14 @@ import navigation.Navigator
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
+                                       override val userAnswersService: UserAnswersService,
                                        override val navigator: Navigator,
                                        override val auth: AuthAction,
                                        override val withMovement: MovementAction,

--- a/.g8/checkboxPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/checkboxPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -2,22 +2,20 @@ package controllers
 
 import base.SpecBase
 import forms.$className$FormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, $className$, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
-class $className$ControllerSpec extends SpecBase with MockitoSugar {
+class $className$ControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -64,9 +62,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/.g8/datePage/app/controllers/$className$Controller.scala
+++ b/.g8/datePage/app/controllers/$className$Controller.scala
@@ -8,14 +8,14 @@ import navigation.Navigator
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
+                                       override val userAnswersService: UserAnswersService,
                                        override val navigator: Navigator,
                                        override val auth: AuthAction,
                                        override val withMovement: MovementAction,

--- a/.g8/datePage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/datePage/generated-test/controllers/$className$ControllerSpec.scala
@@ -4,22 +4,20 @@ import java.time.{LocalDate, ZoneOffset}
 
 import base.SpecBase
 import forms.$className$FormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
-class $className$ControllerSpec extends SpecBase with MockitoSugar {
+class $className$ControllerSpec extends SpecBase with MockUserAnswersService {
 
   val formProvider = new $className$FormProvider()
   private def form = formProvider()
@@ -75,9 +73,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/.g8/intPage/app/controllers/$className$Controller.scala
+++ b/.g8/intPage/app/controllers/$className$Controller.scala
@@ -8,14 +8,14 @@ import navigation.Navigator
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
+                                       override val userAnswersService: UserAnswersService,
                                        override val navigator: Navigator,
                                        override val auth: AuthAction,
                                        override val withMovement: MovementAction,

--- a/.g8/intPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/intPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -2,22 +2,20 @@ package controllers
 
 import base.SpecBase
 import forms.$className$FormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
-class $className$ControllerSpec extends SpecBase with MockitoSugar {
+class $className$ControllerSpec extends SpecBase with MockUserAnswersService {
 
   val formProvider = new $className$FormProvider()
   val form = formProvider()
@@ -66,9 +64,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/.g8/multipleQuestionsPage/app/controllers/$className$Controller.scala
+++ b/.g8/multipleQuestionsPage/app/controllers/$className$Controller.scala
@@ -8,14 +8,14 @@ import navigation.Navigator
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
+                                       override val userAnswersService: UserAnswersService,
                                        override val navigator: Navigator,
                                        override val auth: AuthAction,
                                        override val withMovement: MovementAction,

--- a/.g8/multipleQuestionsPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/multipleQuestionsPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -2,23 +2,21 @@ package controllers
 
 import base.SpecBase
 import forms.$className$FormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, $className$, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
 import play.api.inject.bind
 import play.api.libs.json.Json
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
-class $className$ControllerSpec extends SpecBase with MockitoSugar {
+class $className$ControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -75,9 +73,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/.g8/radioButtonPage/app/controllers/$className$Controller.scala
+++ b/.g8/radioButtonPage/app/controllers/$className$Controller.scala
@@ -8,14 +8,14 @@ import navigation.Navigator
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
+                                       override val userAnswersService: UserAnswersService,
                                        override val navigator: Navigator,
                                        override val auth: AuthAction,
                                        override val withMovement: MovementAction,

--- a/.g8/radioButtonPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/radioButtonPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -2,22 +2,20 @@ package controllers
 
 import base.SpecBase
 import forms.$className$FormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, $className$, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
-class $className$ControllerSpec extends SpecBase with MockitoSugar {
+class $className$ControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -64,9 +62,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/.g8/stringPage/app/controllers/$className$Controller.scala
+++ b/.g8/stringPage/app/controllers/$className$Controller.scala
@@ -8,14 +8,14 @@ import navigation.Navigator
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
+                                       override val userAnswersService: UserAnswersService,
                                        override val navigator: Navigator,
                                        override val auth: AuthAction,
                                        override val withMovement: MovementAction,

--- a/.g8/stringPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/stringPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -2,22 +2,20 @@ package controllers
 
 import base.SpecBase
 import forms.$className$FormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
-class $className$ControllerSpec extends SpecBase with MockitoSugar {
+class $className$ControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -64,9 +62,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/.g8/yesNoPage/app/controllers/$className$Controller.scala
+++ b/.g8/yesNoPage/app/controllers/$className$Controller.scala
@@ -8,14 +8,14 @@ import navigation.Navigator
 import pages.$className$Page
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
 class $className$Controller @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
+                                       override val userAnswersService: UserAnswersService,
                                        override val navigator: Navigator,
                                        override val auth: AuthAction,
                                        override val withMovement: MovementAction,

--- a/.g8/yesNoPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/yesNoPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -2,22 +2,20 @@ package controllers
 
 import base.SpecBase
 import forms.$className$FormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.$className$View
 
 import scala.concurrent.Future
 
-class $className$ControllerSpec extends SpecBase with MockitoSugar {
+class $className$ControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -64,9 +62,7 @@ class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/app/connectors/emcsTfe/UserAnswersConnector.scala
+++ b/app/connectors/emcsTfe/UserAnswersConnector.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.emcsTfe
+
+import config.AppConfig
+import models.UserAnswers
+import models.response.ErrorResponse
+import models.response.emcsTfe.GetMovementResponse
+import play.api.libs.json.Reads
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class UserAnswersConnector @Inject()(val http: HttpClient,
+                                     config: AppConfig) extends UserAnswersHttpParsers {
+
+  override implicit val reads: Reads[UserAnswers] = UserAnswers.format
+
+  lazy val baseUrl: String = config.emcsTfeBaseUrl
+
+  def get(ern: String, arc: String)
+         (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, Option[UserAnswers]]] =
+    http.GET[Either[ErrorResponse, Option[UserAnswers]]](
+      url = s"$baseUrl/user-answers/report-receipt/$ern/$arc"
+    )(GetUserAnswersReads, hc, ec)
+
+  def put(userAnswers: UserAnswers)
+         (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, UserAnswers]] =
+    http.PUT[UserAnswers, Either[ErrorResponse, UserAnswers]](
+      url = s"$baseUrl/user-answers/report-receipt/${userAnswers.ern}/${userAnswers.arc}",
+      body = userAnswers
+    )(UserAnswers.writes, PutUserAnswersReads, hc, ec)
+
+  def delete(ern: String, arc: String)
+            (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, Boolean]] =
+    http.DELETE[Either[ErrorResponse, Boolean]](
+      url = s"$baseUrl/user-answers/report-receipt/$ern/$arc"
+    )(DeleteUserAnswersReads, hc, ec)
+
+}

--- a/app/connectors/emcsTfe/UserAnswersHttpParsers.scala
+++ b/app/connectors/emcsTfe/UserAnswersHttpParsers.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.emcsTfe
+
+import connectors.BaseConnectorUtils
+import models.UserAnswers
+import models.response.{BadRequestError, ErrorResponse, JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.http.Status.{BAD_REQUEST, NO_CONTENT, OK}
+import uk.gov.hmrc.http.{HttpClient, HttpReads, HttpResponse}
+
+trait UserAnswersHttpParsers extends BaseConnectorUtils[UserAnswers] {
+
+  def http: HttpClient
+
+  object GetUserAnswersReads extends HttpReads[Either[ErrorResponse, Option[UserAnswers]]] {
+    override def read(method: String, url: String, response: HttpResponse): Either[ErrorResponse, Option[UserAnswers]] =
+      response.status match {
+        case NO_CONTENT => Right(None)
+        case OK => response.validateJson match {
+          case Some(valid) => Right(Some(valid))
+          case None =>
+            logger.warn(s"[read] Bad JSON response from emcs-tfe")
+            Left(JsonValidationError)
+        }
+        case status =>
+          logger.warn(s"[read] Unexpected status from emcs-tfe: $status")
+          Left(UnexpectedDownstreamResponseError)
+      }
+  }
+
+  object PutUserAnswersReads extends HttpReads[Either[ErrorResponse, UserAnswers]] {
+    override def read(method: String, url: String, response: HttpResponse): Either[ErrorResponse, UserAnswers] =
+      response.status match {
+        case OK => response.validateJson match {
+          case Some(valid) => Right(valid)
+          case None =>
+            logger.warn(s"[read] Bad JSON response from emcs-tfe")
+            Left(JsonValidationError)
+        }
+        case BAD_REQUEST =>
+          logger.error(s"[read] Bad Request response received from emcs-tfe")
+          Left(BadRequestError(response.body))
+        case status =>
+          logger.warn(s"[read] Unexpected status from emcs-tfe: $status")
+          Left(UnexpectedDownstreamResponseError)
+      }
+  }
+
+  object DeleteUserAnswersReads extends HttpReads[Either[ErrorResponse, Boolean]] {
+    override def read(method: String, url: String, response: HttpResponse): Either[ErrorResponse, Boolean] =
+      response.status match {
+        case NO_CONTENT => Right(true)
+        case status =>
+          logger.warn(s"[read] Unexpected status from emcs-tfe: $status")
+          Left(UnexpectedDownstreamResponseError)
+      }
+  }
+}

--- a/app/controllers/AcceptMovementController.scala
+++ b/app/controllers/AcceptMovementController.scala
@@ -23,23 +23,23 @@ import navigation.Navigator
 import pages.AcceptMovementPage
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.AcceptMovementView
 
 import javax.inject.Inject
 import scala.concurrent.Future
 
 class AcceptMovementController @Inject()(
-                                       override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
-                                       override val navigator: Navigator,
-                                       override val auth: AuthAction,
-                                       override val withMovement: MovementAction,
-                                       override val getData: DataRetrievalAction,
-                                       override val requireData: DataRequiredAction,
-                                       formProvider: AcceptMovementFormProvider,
-                                       val controllerComponents: MessagesControllerComponents,
-                                       view: AcceptMovementView
+                                          override val messagesApi: MessagesApi,
+                                          override val userAnswersService: UserAnswersService,
+                                          override val navigator: Navigator,
+                                          override val auth: AuthAction,
+                                          override val withMovement: MovementAction,
+                                          override val getData: DataRetrievalAction,
+                                          override val requireData: DataRequiredAction,
+                                          formProvider: AcceptMovementFormProvider,
+                                          val controllerComponents: MessagesControllerComponents,
+                                          view: AcceptMovementView
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =

--- a/app/controllers/AddMoreInformationController.scala
+++ b/app/controllers/AddMoreInformationController.scala
@@ -20,11 +20,11 @@ import controllers.actions._
 import forms.AddMoreInformationFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.unsatisfactory.{AddDamageInformationPage, AddExcessInformationPage, AddSealsInformationPage, AddShortageInformationPage, DamageInformationPage, ExcessInformationPage, SealsInformationPage, ShortageInformationPage}
+import pages.unsatisfactory._
 import pages.{AddMoreInformationPage, MoreInformationPage, QuestionPage}
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import utils.JsonOptionFormatter
 import views.html.AddMoreInformationView
 
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 
 class AddMoreInformationController @Inject()(
                                               override val messagesApi: MessagesApi,
-                                              override val sessionRepository: SessionRepository,
+                                              override val userAnswersService: UserAnswersService,
                                               override val navigator: Navigator,
                                               override val auth: AuthAction,
                                               override val withMovement: MovementAction,
@@ -98,10 +98,8 @@ class AddMoreInformationController @Inject()(
           case true =>
             saveAndRedirect(yesNoPage, true, mode)
           case false =>
-            for {
-              removedMoreInfo <- save(infoPage, None)
-              saveAndRedirect <- saveAndRedirect(yesNoPage, false, removedMoreInfo, mode)
-            } yield saveAndRedirect
+            val removedMoreInfo = request.userAnswers.set(infoPage, None)
+            saveAndRedirect(yesNoPage, false, removedMoreInfo, mode)
         }
       )
     }

--- a/app/controllers/DateOfArrivalController.scala
+++ b/app/controllers/DateOfArrivalController.scala
@@ -23,7 +23,7 @@ import navigation.Navigator
 import pages.DateOfArrivalPage
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.DateOfArrivalView
 
 import javax.inject.Inject
@@ -31,7 +31,7 @@ import scala.concurrent.Future
 
 class DateOfArrivalController @Inject()(
                                          override val messagesApi: MessagesApi,
-                                         override val sessionRepository: SessionRepository,
+                                         override val userAnswersService: UserAnswersService,
                                          override val navigator: Navigator,
                                          override val auth: AuthAction,
                                          override val withMovement: MovementAction,

--- a/app/controllers/HowMuchIsWrongController.scala
+++ b/app/controllers/HowMuchIsWrongController.scala
@@ -24,22 +24,22 @@ import navigation.Navigator
 import pages.unsatisfactory.HowMuchIsWrongPage
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.HowMuchIsWrongView
 
 import scala.concurrent.Future
 
 class HowMuchIsWrongController @Inject()(
-                                       override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
-                                       override val navigator: Navigator,
-                                       override val auth: AuthAction,
-                                       override val withMovement: MovementAction,
-                                       override val getData: DataRetrievalAction,
-                                       override val requireData: DataRequiredAction,
-                                       formProvider: HowMuchIsWrongFormProvider,
-                                       val controllerComponents: MessagesControllerComponents,
-                                       view: HowMuchIsWrongView
+                                          override val messagesApi: MessagesApi,
+                                          override val userAnswersService: UserAnswersService,
+                                          override val navigator: Navigator,
+                                          override val auth: AuthAction,
+                                          override val withMovement: MovementAction,
+                                          override val getData: DataRetrievalAction,
+                                          override val requireData: DataRequiredAction,
+                                          formProvider: HowMuchIsWrongFormProvider,
+                                          val controllerComponents: MessagesControllerComponents,
+                                          view: HowMuchIsWrongView
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -20,12 +20,12 @@ import controllers.actions.{AuthAction, DataRetrievalAction, MovementAction}
 import models.{NormalMode, UserAnswers}
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 
 import javax.inject.Inject
 
 class IndexController @Inject()(override val messagesApi: MessagesApi,
-                                val sessionRepository: SessionRepository,
+                                val userAnswersService: UserAnswersService,
                                 val controllerComponents: MessagesControllerComponents,
                                 authAction: AuthAction,
                                 withMovement: MovementAction,
@@ -36,7 +36,7 @@ class IndexController @Inject()(override val messagesApi: MessagesApi,
       case Some(answers) => answers
       case _ => UserAnswers(request.internalId, request.ern, request.arc)
     }
-    sessionRepository.set(userAnswers).map { _ =>
+    userAnswersService.set(userAnswers).map { _ =>
       Redirect(routes.DateOfArrivalController.onPageLoad(ern, arc, NormalMode))
     }
   }

--- a/app/controllers/OtherInformationController.scala
+++ b/app/controllers/OtherInformationController.scala
@@ -23,7 +23,7 @@ import navigation.Navigator
 import pages.unsatisfactory._
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.OtherInformationView
 
 import javax.inject.Inject
@@ -31,7 +31,7 @@ import scala.concurrent.Future
 
 class OtherInformationController @Inject()(
                                             override val messagesApi: MessagesApi,
-                                            override val sessionRepository: SessionRepository,
+                                            override val userAnswersService: UserAnswersService,
                                             override val navigator: Navigator,
                                             override val auth: AuthAction,
                                             override val withMovement: MovementAction,

--- a/app/controllers/WrongWithMovementController.scala
+++ b/app/controllers/WrongWithMovementController.scala
@@ -23,23 +23,23 @@ import navigation.Navigator
 import pages.unsatisfactory.WrongWithMovementPage
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.WrongWithMovementView
 
 import javax.inject.Inject
 import scala.concurrent.Future
 
 class WrongWithMovementController @Inject()(
-                                       override val messagesApi: MessagesApi,
-                                       override val sessionRepository: SessionRepository,
-                                       override val navigator: Navigator,
-                                       override val auth: AuthAction,
-                                       override val withMovement: MovementAction,
-                                       override val getData: DataRetrievalAction,
-                                       override val requireData: DataRequiredAction,
-                                       formProvider: WrongWithMovementFormProvider,
-                                       val controllerComponents: MessagesControllerComponents,
-                                       view: WrongWithMovementView
+                                             override val messagesApi: MessagesApi,
+                                             override val userAnswersService: UserAnswersService,
+                                             override val navigator: Navigator,
+                                             override val auth: AuthAction,
+                                             override val withMovement: MovementAction,
+                                             override val getData: DataRetrievalAction,
+                                             override val requireData: DataRequiredAction,
+                                             formProvider: WrongWithMovementFormProvider,
+                                             val controllerComponents: MessagesControllerComponents,
+                                             view: WrongWithMovementView
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -18,16 +18,24 @@ package controllers.actions
 
 import models.requests.{MovementRequest, OptionalDataRequest}
 import play.api.mvc.ActionTransformer
-import repositories.SessionRepository
+import services.UserAnswersService
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class DataRetrievalActionImpl @Inject()(val sessionRepository: SessionRepository)
+class DataRetrievalActionImpl @Inject()(val userAnswersService: UserAnswersService)
                                        (implicit val executionContext: ExecutionContext) extends DataRetrievalAction {
 
   override protected def transform[A](request: MovementRequest[A]): Future[OptionalDataRequest[A]] = {
-    sessionRepository.get(request.internalId, request.ern, request.arc).map {
+
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(
+      session = request.session,
+      request = request
+    )
+
+    userAnswersService.get(request.ern, request.arc).map {
       OptionalDataRequest(request, _)
     }
   }

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -17,7 +17,7 @@
 package models
 
 import play.api.libs.json._
-import queries.{Gettable, Query, Settable}
+import queries.{Gettable, Settable}
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant

--- a/app/models/response/ErrorResponse.scala
+++ b/app/models/response/ErrorResponse.scala
@@ -27,3 +27,7 @@ case object UnexpectedDownstreamResponseError extends ErrorResponse {
 case object JsonValidationError extends ErrorResponse {
   val message = "JSON validation error"
 }
+
+case class BadRequestError(msg: String) extends ErrorResponse {
+  val message = s"Bad Request returned from downstream service. With message: $msg"
+}

--- a/app/services/UserAnswersService.scala
+++ b/app/services/UserAnswersService.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.emcsTfe.UserAnswersConnector
+import models.UserAnswers
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NoStackTrace
+
+@Singleton
+class UserAnswersService @Inject()(userAnswersConnector: UserAnswersConnector)(implicit ec: ExecutionContext) {
+
+  def get(ern: String, arc: String)(implicit hc: HeaderCarrier): Future[Option[UserAnswers]] =
+    userAnswersConnector.get(ern, arc).map {
+      case Right(answers) => answers
+      case Left(_) => throw UserAnswersException(s"Failed to retrieve UserAnswers from emcs-tfe for ern: '$ern' & arc: '$arc'")
+    }
+
+  def set(answers: UserAnswers)(implicit hc: HeaderCarrier): Future[UserAnswers] = {
+    userAnswersConnector.put(answers).map {
+      case Right(answers) => answers
+      case Left(_) => throw UserAnswersException(s"Failed to store UserAnswers in emcs-tfe for ern: '${answers.ern}' & arc: '${answers.arc}'")
+    }
+  }
+
+  def clear(answers: UserAnswers)(implicit hc: HeaderCarrier): Future[Boolean] =
+    userAnswersConnector.delete(answers.ern, answers.arc).map {
+      case Right(response) => response
+      case Left(_) => throw UserAnswersException(s"Failed to delete UserAnswers from emcs-tfe for ern: '${answers.ern}' & arc: '${answers.arc}'")
+    }
+}
+
+case class UserAnswersException(msg: String) extends Exception(msg) with NoStackTrace

--- a/test-utils/fixtures/BaseFixtures.scala
+++ b/test-utils/fixtures/BaseFixtures.scala
@@ -19,6 +19,9 @@ package fixtures
 import models.UserAnswers
 import play.api.mvc.Call
 
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
 trait BaseFixtures {
 
   val testCredId: String = "credId"
@@ -28,5 +31,10 @@ trait BaseFixtures {
   val testConfirmationReference = "UYVQBLMXCYK6HAEBZI7TSWAQ6XDTXFYU"
   val testOnwardRoute = Call("GET", "/foo")
 
-  val emptyUserAnswers: UserAnswers = UserAnswers(testInternalId, testErn, testArc)
+  val emptyUserAnswers: UserAnswers = UserAnswers(
+    internalId = testInternalId,
+    ern = testErn,
+    arc = testArc,
+    lastUpdated = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+  )
 }

--- a/test/connectors/emcsTfe/UserAnswersConnectorSpec.scala
+++ b/test/connectors/emcsTfe/UserAnswersConnectorSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.emcsTfe
+
+import base.SpecBase
+import config.AppConfig
+import mocks.connectors.MockHttpClient
+import models.response.{JsonValidationError, UnexpectedDownstreamResponseError}
+import org.scalatest.BeforeAndAfterAll
+import play.api.Play
+import play.api.http.{HeaderNames, MimeTypes, Status}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class UserAnswersConnectorSpec extends SpecBase with Status with MimeTypes with HeaderNames with MockHttpClient with BeforeAndAfterAll {
+
+  lazy val app = applicationBuilder(userAnswers = None).build()
+
+  override def beforeAll(): Unit = {
+    Play.start(app)
+  }
+
+  override def afterAll(): Unit = {
+    Play.stop(app)
+  }
+
+  implicit lazy val hc: HeaderCarrier = HeaderCarrier()
+  implicit lazy val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+  lazy val appConfig = app.injector.instanceOf[AppConfig]
+
+  lazy val connector = new UserAnswersConnector(mockHttpClient, appConfig)
+
+  ".get()" - {
+
+    "should return a successful response" - {
+
+      "when downstream call is successful and returns some JSON" in {
+
+        MockHttpClient.get(s"${appConfig.emcsTfeBaseUrl}/user-answers/report-receipt/$testErn/$testArc")
+          .returns(Future.successful(Right(Some(emptyUserAnswers))))
+
+        connector.get(testErn, testArc).futureValue mustBe Right(Some(emptyUserAnswers))
+      }
+
+      "when downstream call is successful and returns None" in {
+
+        MockHttpClient.get(s"${appConfig.emcsTfeBaseUrl}/user-answers/report-receipt/$testErn/$testArc")
+          .returns(Future.successful(Right(None)))
+
+        connector.get(testErn, testArc).futureValue mustBe Right(None)
+      }
+    }
+
+    "should return an error response" - {
+
+      "when downstream call fails" in {
+
+        MockHttpClient.get(s"${appConfig.emcsTfeBaseUrl}/user-answers/report-receipt/$testErn/$testArc")
+          .returns(Future.successful(Left(JsonValidationError)))
+
+        connector.get(testErn, testArc).futureValue mustBe Left(JsonValidationError)
+      }
+    }
+  }
+
+  ".put()" - {
+
+    "should return a successful response" - {
+
+      "when downstream call is successful and returns some JSON" in {
+
+        MockHttpClient.put(
+          url = s"${appConfig.emcsTfeBaseUrl}/user-answers/report-receipt/$testErn/$testArc",
+          body = emptyUserAnswers
+        ).returns(Future.successful(Right(emptyUserAnswers)))
+
+        connector.put(emptyUserAnswers).futureValue mustBe Right(emptyUserAnswers)
+      }
+    }
+
+    "should return an error response" - {
+
+      "when downstream call fails" in {
+
+        MockHttpClient.put(
+          url = s"${appConfig.emcsTfeBaseUrl}/user-answers/report-receipt/$testErn/$testArc",
+          body = emptyUserAnswers
+        ).returns(Future.successful(Left(JsonValidationError)))
+
+        connector.put(emptyUserAnswers).futureValue mustBe Left(JsonValidationError)
+      }
+    }
+  }
+
+  ".delete()" - {
+
+    "should return a successful response" - {
+
+      "when downstream call is successful" in {
+
+        MockHttpClient.delete(
+          url = s"${appConfig.emcsTfeBaseUrl}/user-answers/report-receipt/$testErn/$testArc"
+        ).returns(Future.successful(Right(true)))
+
+        connector.delete(testErn, testArc).futureValue mustBe Right(true)
+      }
+    }
+
+    "should return an error response" - {
+
+      "when downstream call fails" in {
+
+        MockHttpClient.delete(
+          url = s"${appConfig.emcsTfeBaseUrl}/user-answers/report-receipt/$testErn/$testArc"
+        ).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+        connector.delete(testErn, testArc).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+      }
+    }
+  }
+}

--- a/test/connectors/emcsTfe/UserAnswersHttpParsersSpec.scala
+++ b/test/connectors/emcsTfe/UserAnswersHttpParsersSpec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.emcsTfe
+
+import base.SpecBase
+import mocks.connectors.MockHttpClient
+import models.UserAnswers
+import models.response.{BadRequestError, JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.http.{HeaderNames, MimeTypes, Status}
+import play.api.libs.json.{Json, Reads}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+
+class UserAnswersHttpParsersSpec extends SpecBase with Status with MimeTypes with HeaderNames with MockHttpClient {
+
+  lazy implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  lazy val httpParser = new UserAnswersHttpParsers {
+    override implicit val reads: Reads[UserAnswers] = UserAnswers.format
+    override def http: HttpClient = mockHttpClient
+  }
+
+  "GetUserAnswersReads.read(method: String, url: String, response: HttpResponse)" - {
+
+    "should return a successful response" - {
+
+      "when valid JSON is returned that can be parsed to the model" in {
+
+        val httpResponse = HttpResponse(Status.OK, Json.toJson(emptyUserAnswers), Map())
+
+        httpParser.GetUserAnswersReads.read("", "", httpResponse) mustBe Right(Some(emptyUserAnswers))
+      }
+
+      "when NO_CONTENT is returned" in {
+
+        val httpResponse = HttpResponse(Status.NO_CONTENT, "")
+
+        httpParser.GetUserAnswersReads.read("", "", httpResponse) mustBe Right(None)
+      }
+    }
+
+    "should return UnexpectedDownstreamError" - {
+
+      s"when status is not OK (${Status.OK})" in {
+
+        val httpResponse = HttpResponse(Status.INTERNAL_SERVER_ERROR, Json.obj(), Map())
+
+        httpParser.GetUserAnswersReads.read("", "", httpResponse) mustBe Left(UnexpectedDownstreamResponseError)
+      }
+    }
+
+    "should return JsonValidationError" - {
+
+      s"when response does not contain Json" in {
+
+        val httpResponse = HttpResponse(Status.OK, "", Map())
+
+        httpParser.GetUserAnswersReads.read("", "", httpResponse) mustBe Left(JsonValidationError)
+      }
+
+      s"when response contains JSON but can't be deserialized to model" in {
+
+        val httpResponse = HttpResponse(Status.OK, Json.obj(), Map())
+
+        httpParser.GetUserAnswersReads.read("", "", httpResponse) mustBe Left(JsonValidationError)
+      }
+    }
+  }
+
+  "PutUserAnswersReads.read(method: String, url: String, response: HttpResponse)" - {
+
+    "should return a successful response" - {
+
+      "when valid JSON is returned that can be parsed to the model" in {
+
+        val httpResponse = HttpResponse(Status.OK, Json.toJson(emptyUserAnswers), Map())
+
+        httpParser.PutUserAnswersReads.read("", "", httpResponse) mustBe Right(emptyUserAnswers)
+      }
+    }
+
+    "should return BadRequest" - {
+
+      s"when status is BAD_REQUEST (${Status.BAD_REQUEST})" in {
+
+        val httpResponse = HttpResponse(Status.BAD_REQUEST, "errMsg")
+
+        httpParser.PutUserAnswersReads.read("", "", httpResponse) mustBe Left(BadRequestError("errMsg"))
+      }
+    }
+
+    "should return UnexpectedDownstreamError" - {
+
+      s"when status is not OK (${Status.OK})" in {
+
+        val httpResponse = HttpResponse(Status.INTERNAL_SERVER_ERROR, Json.obj(), Map())
+
+        httpParser.PutUserAnswersReads.read("", "", httpResponse) mustBe Left(UnexpectedDownstreamResponseError)
+      }
+    }
+
+    "should return JsonValidationError" - {
+
+      s"when response does not contain Json" in {
+
+        val httpResponse = HttpResponse(Status.OK, "", Map())
+
+        httpParser.PutUserAnswersReads.read("", "", httpResponse) mustBe Left(JsonValidationError)
+      }
+
+      s"when response contains JSON but can't be deserialized to model" in {
+
+        val httpResponse = HttpResponse(Status.OK, Json.obj(), Map())
+
+        httpParser.PutUserAnswersReads.read("", "", httpResponse) mustBe Left(JsonValidationError)
+      }
+    }
+  }
+
+  "DeleteUserAnswersReads.read(method: String, url: String, response: HttpResponse)" - {
+
+    "should return a successful response" - {
+
+      "when NO_CONTENT is returned" in {
+
+        val httpResponse = HttpResponse(Status.NO_CONTENT, "")
+
+        httpParser.DeleteUserAnswersReads.read("", "", httpResponse) mustBe Right(true)
+      }
+    }
+
+    "should return UnexpectedDownstreamError" - {
+
+      s"when status is not OK (${Status.OK})" in {
+
+        val httpResponse = HttpResponse(Status.INTERNAL_SERVER_ERROR, Json.obj(), Map())
+
+        httpParser.DeleteUserAnswersReads.read("", "", httpResponse) mustBe Left(UnexpectedDownstreamResponseError)
+      }
+    }
+  }
+}

--- a/test/controllers/AcceptMovementControllerSpec.scala
+++ b/test/controllers/AcceptMovementControllerSpec.scala
@@ -18,22 +18,20 @@ package controllers
 
 import base.SpecBase
 import forms.AcceptMovementFormProvider
+import mocks.services.MockUserAnswersService
 import models.{AcceptMovement, NormalMode}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.AcceptMovementPage
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.AcceptMovementView
 
 import scala.concurrent.Future
 
-class AcceptMovementControllerSpec extends SpecBase with MockitoSugar {
+class AcceptMovementControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -80,15 +78,14 @@ class AcceptMovementControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      val updatedAnswers = emptyUserAnswers.set(AcceptMovementPage, AcceptMovement.values.head)
+      MockUserAnswersService.set(updatedAnswers).returns(Future.successful(updatedAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[UserAnswersService].toInstance(mockUserAnswersService)
           )
           .build()
 

--- a/test/controllers/DateOfArrivalControllerSpec.scala
+++ b/test/controllers/DateOfArrivalControllerSpec.scala
@@ -18,25 +18,23 @@ package controllers
 
 import base.SpecBase
 import forms.DateOfArrivalFormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.DateOfArrivalPage
 import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import utils.TimeMachine
 import views.html.DateOfArrivalView
 
 import java.time.{Instant, LocalDateTime}
 import scala.concurrent.Future
 
-class DateOfArrivalControllerSpec extends SpecBase with MockitoSugar {
+class DateOfArrivalControllerSpec extends SpecBase with MockUserAnswersService {
 
   val fixedNow = LocalDateTime.now()
   val dateOfDispatch = fixedNow.minusDays(3)
@@ -100,15 +98,15 @@ class DateOfArrivalControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
+      val updatedAnswers = emptyUserAnswers.set(DateOfArrivalPage, validAnswer)
 
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set(updatedAnswers).returns(Future.successful(updatedAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[UserAnswersService].toInstance(mockUserAnswersService)
           )
           .build()
 

--- a/test/controllers/HowMuchIsWrongControllerSpec.scala
+++ b/test/controllers/HowMuchIsWrongControllerSpec.scala
@@ -18,22 +18,20 @@ package controllers
 
 import base.SpecBase
 import forms.HowMuchIsWrongFormProvider
+import mocks.services.MockUserAnswersService
 import models.{HowMuchIsWrong, NormalMode}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.unsatisfactory.HowMuchIsWrongPage
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.HowMuchIsWrongView
 
 import scala.concurrent.Future
 
-class HowMuchIsWrongControllerSpec extends SpecBase with MockitoSugar {
+class HowMuchIsWrongControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -80,15 +78,14 @@ class HowMuchIsWrongControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      val updatedAnswers = emptyUserAnswers.set(HowMuchIsWrongPage, HowMuchIsWrong.values.head)
+      MockUserAnswersService.set(updatedAnswers).returns(Future.successful(updatedAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[UserAnswersService].toInstance(mockUserAnswersService)
           )
           .build()
 

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -17,25 +17,58 @@
 package controllers
 
 import base.SpecBase
+import mocks.services.MockUserAnswersService
 import models.NormalMode
+import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import services.UserAnswersService
 
-class IndexControllerSpec extends SpecBase {
+import scala.concurrent.Future
+
+class IndexControllerSpec extends SpecBase with MockUserAnswersService {
 
   "Index Controller" - {
 
-    "must return OK and the correct view for a GET" in {
+    "when existing UserAnswers don't exist" - {
 
-      val application = applicationBuilder(userAnswers = None).build()
+      "must Initialise the UserAnswers and redirect to DateOfArrival" in {
 
-      running(application) {
-        val request = FakeRequest(GET, routes.IndexController.onPageLoad(testErn, testArc).url)
+        MockUserAnswersService.set().returns(Future.successful(emptyUserAnswers))
 
-        val result = route(application, request).value
+        val application = applicationBuilder(userAnswers = None).overrides(
+          bind[UserAnswersService].toInstance(mockUserAnswersService)
+        ).build()
 
-        status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(routes.DateOfArrivalController.onPageLoad(testErn, testArc, NormalMode).url)
+        running(application) {
+          val request = FakeRequest(GET, routes.IndexController.onPageLoad(testErn, testArc).url)
+
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result) mustBe Some(routes.DateOfArrivalController.onPageLoad(testErn, testArc, NormalMode).url)
+        }
+      }
+    }
+
+    "when existing UserAnswers exist" - {
+
+      "must use the existing answers and redirect to DateOfArrival" in {
+
+        MockUserAnswersService.set(emptyUserAnswers).returns(Future.successful(emptyUserAnswers))
+
+        val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).overrides(
+          bind[UserAnswersService].toInstance(mockUserAnswersService)
+        ).build()
+
+        running(application) {
+          val request = FakeRequest(GET, routes.IndexController.onPageLoad(testErn, testArc).url)
+
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result) mustBe Some(routes.DateOfArrivalController.onPageLoad(testErn, testArc, NormalMode).url)
+        }
       }
     }
   }

--- a/test/controllers/KeepAliveControllerSpec.scala
+++ b/test/controllers/KeepAliveControllerSpec.scala
@@ -17,11 +17,10 @@
 package controllers
 
 import base.SpecBase
-import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
-class KeepAliveControllerSpec extends SpecBase with MockitoSugar {
+class KeepAliveControllerSpec extends SpecBase {
 
   "keepAlive" - {
 

--- a/test/controllers/OtherInformationControllerSpec.scala
+++ b/test/controllers/OtherInformationControllerSpec.scala
@@ -18,23 +18,21 @@ package controllers
 
 import base.SpecBase
 import forms.OtherInformationFormProvider
+import mocks.services.MockUserAnswersService
 import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.unsatisfactory._
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import utils.JsonOptionFormatter
 import views.html.OtherInformationView
 
 import scala.concurrent.Future
 
-class OtherInformationControllerSpec extends SpecBase with MockitoSugar with JsonOptionFormatter {
+class OtherInformationControllerSpec extends SpecBase with JsonOptionFormatter with MockUserAnswersService {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
@@ -83,15 +81,15 @@ class OtherInformationControllerSpec extends SpecBase with MockitoSugar with Jso
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
+      val updatedAnswers = emptyUserAnswers.set(OtherInformationPage, "answer")
 
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      MockUserAnswersService.set(updatedAnswers).returns(Future.successful(updatedAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[UserAnswersService].toInstance(mockUserAnswersService)
           )
           .build()
 
@@ -109,15 +107,11 @@ class OtherInformationControllerSpec extends SpecBase with MockitoSugar with Jso
 
     "must return a Bad Request and errors when NO data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
-
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[UserAnswersService].toInstance(mockUserAnswersService)
           )
           .build()
 

--- a/test/controllers/WrongWithMovementControllerSpec.scala
+++ b/test/controllers/WrongWithMovementControllerSpec.scala
@@ -18,22 +18,20 @@ package controllers
 
 import base.SpecBase
 import forms.WrongWithMovementFormProvider
+import mocks.services.MockUserAnswersService
 import models.{NormalMode, WrongWithMovement}
 import navigation.{FakeNavigator, Navigator}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import pages.unsatisfactory.WrongWithMovementPage
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import services.UserAnswersService
 import views.html.WrongWithMovementView
 
 import scala.concurrent.Future
 
-class WrongWithMovementControllerSpec extends SpecBase with MockitoSugar {
+class WrongWithMovementControllerSpec extends SpecBase with MockUserAnswersService {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -80,15 +78,14 @@ class WrongWithMovementControllerSpec extends SpecBase with MockitoSugar {
 
     "must redirect to the next page when valid data is submitted" in {
 
-      val mockSessionRepository = mock[SessionRepository]
-
-      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      val updatedAnswers = emptyUserAnswers.set(WrongWithMovementPage, Set(WrongWithMovement.values.head))
+      MockUserAnswersService.set(updatedAnswers).returns(Future.successful(updatedAnswers))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[UserAnswersService].toInstance(mockUserAnswersService)
           )
           .build()
 

--- a/test/mocks/connectors/MockUserAnswersConnector.scala
+++ b/test/mocks/connectors/MockUserAnswersConnector.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.connectors
+
+import connectors.emcsTfe.UserAnswersConnector
+import models.UserAnswers
+import models.response.ErrorResponse
+import org.scalamock.handlers.{CallHandler3, CallHandler4}
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockUserAnswersConnector extends MockFactory {
+
+  lazy val mockUserAnswersConnector: UserAnswersConnector = mock[UserAnswersConnector]
+
+  object MockUserAnswersConnector {
+
+    def get(ern: String, arc: String): CallHandler4[String, String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, Option[UserAnswers]]]] =
+      (mockUserAnswersConnector.get(_: String, _: String)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(ern, arc, *, *)
+
+    def put(userAnswers: UserAnswers): CallHandler3[UserAnswers, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, UserAnswers]]] =
+      (mockUserAnswersConnector.put(_: UserAnswers)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(userAnswers, *, *)
+
+    def delete(ern: String, arc: String): CallHandler4[String, String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, Boolean]]] =
+      (mockUserAnswersConnector.delete(_: String, _: String)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(ern, arc, *, *)
+  }
+}

--- a/test/mocks/services/MockUserAnswersService.scala
+++ b/test/mocks/services/MockUserAnswersService.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.services
+
+import models.UserAnswers
+import org.scalamock.handlers.{CallHandler2, CallHandler3}
+import org.scalamock.scalatest.MockFactory
+import services.UserAnswersService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+trait MockUserAnswersService extends MockFactory {
+
+  lazy val mockUserAnswersService: UserAnswersService = mock[UserAnswersService]
+
+  object MockUserAnswersService {
+
+    def get(ern: String, arc: String): CallHandler3[String, String, HeaderCarrier, Future[Option[UserAnswers]]] =
+      (mockUserAnswersService.get(_: String, _: String)(_: HeaderCarrier))
+        .expects(ern, arc, *)
+
+    def set(userAnswers: UserAnswers): CallHandler2[UserAnswers, HeaderCarrier, Future[UserAnswers]] =
+      (mockUserAnswersService.set(_: UserAnswers)(_: HeaderCarrier))
+        .expects(userAnswers, *)
+
+    def set(): CallHandler2[UserAnswers, HeaderCarrier, Future[UserAnswers]] =
+      (mockUserAnswersService.set(_: UserAnswers)(_: HeaderCarrier))
+        .expects(*, *)
+
+    def clear(userAnswers: UserAnswers): CallHandler2[UserAnswers, HeaderCarrier, Future[Boolean]] =
+      (mockUserAnswersService.clear(_: UserAnswers)(_: HeaderCarrier))
+        .expects(userAnswers, *)
+  }
+}

--- a/test/services/UserAnswersServiceSpec.scala
+++ b/test/services/UserAnswersServiceSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import mocks.connectors.MockUserAnswersConnector
+import models.response.UnexpectedDownstreamResponseError
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class UserAnswersServiceSpec extends SpecBase with MockUserAnswersConnector {
+
+  implicit val hc = HeaderCarrier()
+  implicit val ec = ExecutionContext.global
+
+  lazy val testService = new UserAnswersService(mockUserAnswersConnector)
+
+  ".get()" - {
+
+    "should return Some(UserAnswers)" - {
+
+      "when Connector returns success from downstream" in {
+
+        MockUserAnswersConnector.get(testErn, testArc).returns(Future.successful(Right(Some(emptyUserAnswers))))
+        testService.get(testErn, testArc).futureValue mustBe Some(emptyUserAnswers)
+      }
+    }
+
+    "should return None" - {
+
+      "when Connector returns success from downstream with no data" in {
+
+        MockUserAnswersConnector.get(testErn, testArc).returns(Future.successful(Right(None)))
+        testService.get(testErn, testArc).futureValue mustBe None
+      }
+    }
+
+    "should throw UserAnswersException" - {
+
+      "when Connector returns failure from downstream" in {
+
+        MockUserAnswersConnector.get(testErn, testArc).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+        intercept[UserAnswersException](await(testService.get(testErn, testArc))).msg mustBe
+          s"Failed to retrieve UserAnswers from emcs-tfe for ern: '$testErn' & arc: '$testArc'"
+      }
+    }
+  }
+
+  ".put()" - {
+
+    "should return UserAnswers" - {
+
+      "when Connector returns success from downstream" in {
+
+        MockUserAnswersConnector.put(emptyUserAnswers).returns(Future.successful(Right(emptyUserAnswers)))
+        testService.set(emptyUserAnswers).futureValue mustBe emptyUserAnswers
+      }
+    }
+
+    "should throw UserAnswersException" - {
+
+      "when Connector returns failure from downstream" in {
+
+        MockUserAnswersConnector.put(emptyUserAnswers).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+        intercept[UserAnswersException](await(testService.set(emptyUserAnswers))).msg mustBe
+          s"Failed to store UserAnswers in emcs-tfe for ern: '$testErn' & arc: '$testArc'"
+      }
+    }
+  }
+
+  ".delete()" - {
+
+    "should return true" - {
+
+      "when Connector returns success from downstream" in {
+
+        MockUserAnswersConnector.delete(testErn, testArc).returns(Future.successful(Right(true)))
+        testService.clear(emptyUserAnswers).futureValue mustBe true
+      }
+    }
+
+    "should throw UserAnswersException" - {
+
+      "when Connector returns failure from downstream" in {
+
+        MockUserAnswersConnector.delete(testErn, testArc).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+        intercept[UserAnswersException](await(testService.clear(emptyUserAnswers))).msg mustBe
+          s"Failed to delete UserAnswers from emcs-tfe for ern: '$testErn' & arc: '$testArc'"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Note**:
- Updated the scaffolds at the same time so that future pages should get created OK.
- I've not removed the SessionRepository yet from the PR as thought that could be done as a separate sub-task