### PR TITLE
[ETFE-1098] Add the destinationType to the Report of Receipt submission

### DIFF
--- a/app/models/DestinationType.scala
+++ b/app/models/DestinationType.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+sealed trait DestinationType
+
+object DestinationType extends Enumerable.Implicits {
+
+  case object TaxWarehouse extends WithName("1") with DestinationType
+  case object RegisteredConsignee extends WithName("2") with DestinationType
+  case object TemporaryRegisteredConsignee extends WithName("3") with DestinationType
+  case object DirectDelivery extends WithName("4") with DestinationType
+  case object ExemptedOrganisations extends WithName("5") with DestinationType
+  case object Export extends WithName("6") with DestinationType
+  case object UnknownDestination extends WithName("8") with DestinationType
+
+  val values: Seq[DestinationType] = Seq(
+    TaxWarehouse,
+    RegisteredConsignee,
+    TemporaryRegisteredConsignee,
+    DirectDelivery,
+    ExemptedOrganisations,
+    Export,
+    UnknownDestination
+  )
+
+  implicit val enumerable: Enumerable[DestinationType] =
+    Enumerable(values.map(v => v.toString -> v): _*)
+}

--- a/app/models/response/emcsTfe/GetMovementResponse.scala
+++ b/app/models/response/emcsTfe/GetMovementResponse.scala
@@ -16,6 +16,7 @@
 
 package models.response.emcsTfe
 
+import models.DestinationType
 import models.submitReportOfReceipt.TraderModel
 import play.api.libs.json.{Json, Reads}
 
@@ -24,6 +25,7 @@ import java.time.LocalDate
 
 case class GetMovementResponse(arc: String,
                                sequenceNumber: Int,
+                               destinationType: DestinationType,
                                consigneeTrader: Option[TraderModel],
                                deliveryPlaceTrader: Option[TraderModel],
                                localReferenceNumber: String,

--- a/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
+++ b/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
@@ -19,7 +19,7 @@ package models.submitReportOfReceipt
 import config.AppConfig
 import models.WrongWithMovement._
 import models.response.emcsTfe.GetMovementResponse
-import models.{AcceptMovement, UserAnswers}
+import models.{AcceptMovement, DestinationType, UserAnswers}
 import pages.{AcceptMovementPage, DateOfArrivalPage, MoreInformationPage}
 import play.api.libs.json.{Format, Json}
 import utils.{JsonOptionFormatter, ModelConstructorHelpers}
@@ -28,6 +28,7 @@ import java.time.LocalDate
 
 case class SubmitReportOfReceiptModel(arc: String,
                                       sequenceNumber: Int,
+                                      destinationType: DestinationType,
                                       consigneeTrader: Option[TraderModel],
                                       deliveryPlaceTrader: Option[TraderModel],
                                       destinationOffice: String,
@@ -44,6 +45,7 @@ object SubmitReportOfReceiptModel extends JsonOptionFormatter with ModelConstruc
     SubmitReportOfReceiptModel(
       arc = movementDetails.arc,
       sequenceNumber = movementDetails.sequenceNumber,
+      destinationType = movementDetails.destinationType,
       consigneeTrader = movementDetails.consigneeTrader,
       deliveryPlaceTrader = movementDetails.deliveryPlaceTrader,
       destinationOffice = appConfig.destinationOffice,

--- a/test-utils/fixtures/GetMovementResponseFixtures.scala
+++ b/test-utils/fixtures/GetMovementResponseFixtures.scala
@@ -16,6 +16,7 @@
 
 package fixtures
 
+import models.DestinationType.TaxWarehouse
 import models.{CategoryOfWine, ReferenceDataCategoryOfWine}
 import models.response.emcsTfe.{GetMovementResponse, MovementItem, Packaging, WineProduct}
 import play.api.libs.json.{JsValue, Json}
@@ -85,6 +86,7 @@ trait GetMovementResponseFixtures { _: BaseFixtures =>
   val getMovementResponseModel: GetMovementResponse = GetMovementResponse(
     arc = testArc,
     sequenceNumber = 1,
+    destinationType = TaxWarehouse,
     consigneeTrader = None,
     deliveryPlaceTrader = None,
     localReferenceNumber = "MyLrn",
@@ -99,6 +101,7 @@ trait GetMovementResponseFixtures { _: BaseFixtures =>
   val getMovementResponseInputJson: JsValue = Json.obj(
     "arc" -> testArc,
     "sequenceNumber" -> 1,
+    "destinationType" -> "1",
     "localReferenceNumber" -> "MyLrn",
     "eadStatus" -> "MyEadStatus",
     "consignorName" -> "MyConsignor",

--- a/test-utils/fixtures/SubmitReportOfReceiptFixtures.scala
+++ b/test-utils/fixtures/SubmitReportOfReceiptFixtures.scala
@@ -17,6 +17,7 @@
 package fixtures
 
 import models.AcceptMovement._
+import models.DestinationType.TaxWarehouse
 import models.response.emcsTfe.SubmitReportOfReceiptResponse
 import models.submitReportOfReceipt.SubmitReportOfReceiptModel
 import play.api.libs.json.Json
@@ -33,6 +34,7 @@ trait SubmitReportOfReceiptFixtures extends BaseFixtures
   val maxSubmitReportOfReceiptModel = SubmitReportOfReceiptModel(
     arc = testArc,
     sequenceNumber = 1,
+    destinationType = TaxWarehouse,
     consigneeTrader = Some(maxTraderModel),
     deliveryPlaceTrader = Some(maxTraderModel.copy(eoriNumber = None)),
     destinationOffice = destinationOfficeId,
@@ -49,6 +51,7 @@ trait SubmitReportOfReceiptFixtures extends BaseFixtures
   val minSubmitReportOfReceiptModel = SubmitReportOfReceiptModel(
     arc = testArc,
     sequenceNumber = 1,
+    destinationType = TaxWarehouse,
     consigneeTrader = Some(minTraderModel),
     deliveryPlaceTrader = Some(minTraderModel),
     destinationOffice = destinationOfficeId,

--- a/test-utils/fixtures/audit/SubmitReportOfReceiptAuditModelFixture.scala
+++ b/test-utils/fixtures/audit/SubmitReportOfReceiptAuditModelFixture.scala
@@ -17,6 +17,7 @@
 package fixtures.audit
 
 import models.AcceptMovement._
+import models.DestinationType.DirectDelivery
 import models.WrongWithMovement.{BrokenSeals, Damaged, Excess, Other}
 import models.submitReportOfReceipt.{AddressModel, ReceiptedItemsModel, SubmitReportOfReceiptModel, TraderModel, UnsatisfactoryModel}
 import play.api.libs.json.{JsValue, Json}
@@ -34,6 +35,7 @@ object SubmitReportOfReceiptAuditModelFixture {
       submission = SubmitReportOfReceiptModel(
         arc = "ARC",
         sequenceNumber = 1,
+        destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
           traderId = Some("id"),
           traderName = Some("name"),
@@ -61,6 +63,7 @@ object SubmitReportOfReceiptAuditModelFixture {
       submission = SubmitReportOfReceiptModel(
         arc = "ARC",
         sequenceNumber = 1,
+        destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
           traderId = Some("id"),
           traderName = Some("name"),
@@ -118,6 +121,7 @@ object SubmitReportOfReceiptAuditModelFixture {
       submission = SubmitReportOfReceiptModel(
       arc = "ARC",
       sequenceNumber = 1,
+        destinationType = DirectDelivery,
       consigneeTrader = Some(TraderModel(
         traderId = Some("id"),
         traderName = Some("name"),
@@ -175,6 +179,7 @@ object SubmitReportOfReceiptAuditModelFixture {
       submission = SubmitReportOfReceiptModel(
         arc = "ARC",
         sequenceNumber = 1,
+        destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
           traderId = Some("id"),
           traderName = Some("name"),

--- a/test/models/DestinationTypeSpec.scala
+++ b/test/models/DestinationTypeSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import models.DestinationType._
+
+class DestinationTypeSpec extends SpecBase {
+
+  "DestinationType" - {
+
+    "have the correct codes" in {
+      TaxWarehouse.toString mustBe "1"
+      RegisteredConsignee.toString mustBe "2"
+      TemporaryRegisteredConsignee.toString mustBe "3"
+      DirectDelivery.toString mustBe "4"
+      ExemptedOrganisations.toString mustBe "5"
+      Export.toString mustBe "6"
+    }
+  }
+}

--- a/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
+++ b/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
@@ -71,6 +71,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase with SubmitReportOfReceipt
           submission mustBe SubmitReportOfReceiptModel(
             arc = getMovementResponseModel.arc,
             sequenceNumber = getMovementResponseModel.sequenceNumber,
+            destinationType = getMovementResponseModel.destinationType,
             consigneeTrader = getMovementResponseModel.consigneeTrader,
             deliveryPlaceTrader = getMovementResponseModel.deliveryPlaceTrader,
             destinationOffice = "GB004098",
@@ -110,6 +111,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase with SubmitReportOfReceipt
           submission mustBe SubmitReportOfReceiptModel(
             arc = getMovementResponseModel.arc,
             sequenceNumber = getMovementResponseModel.sequenceNumber,
+            destinationType = getMovementResponseModel.destinationType,
             consigneeTrader = getMovementResponseModel.consigneeTrader,
             deliveryPlaceTrader = getMovementResponseModel.deliveryPlaceTrader,
             destinationOffice = "GB004098",
@@ -166,6 +168,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase with SubmitReportOfReceipt
           submission mustBe SubmitReportOfReceiptModel(
             arc = getMovementResponseModel.arc,
             sequenceNumber = getMovementResponseModel.sequenceNumber,
+            destinationType = getMovementResponseModel.destinationType,
             consigneeTrader = getMovementResponseModel.consigneeTrader,
             deliveryPlaceTrader = getMovementResponseModel.deliveryPlaceTrader,
             destinationOffice = "GB004098",
@@ -211,6 +214,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase with SubmitReportOfReceipt
           submission mustBe SubmitReportOfReceiptModel(
             arc = getMovementResponseModel.arc,
             sequenceNumber = getMovementResponseModel.sequenceNumber,
+            destinationType = getMovementResponseModel.destinationType,
             consigneeTrader = getMovementResponseModel.consigneeTrader,
             deliveryPlaceTrader = getMovementResponseModel.deliveryPlaceTrader,
             destinationOffice = "GB004098",


### PR DESCRIPTION
**Note:** requires associated BE PR to be reviewed and merged at the same time:
- https://github.com/hmrc/emcs-tfe/pull/42