### PR TITLE
[ETFE-1144] Add functionality so that we can decide whether to use the cache for the movement or not

### DIFF
--- a/.g8/characterCountPage/app/controllers/$className$Controller.scala
+++ b/.g8/characterCountPage/app/controllers/$className$Controller.scala
@@ -27,12 +27,12 @@ class $className$Controller @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm($className$Page, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/.g8/checkboxPage/app/controllers/$className$Controller.scala
+++ b/.g8/checkboxPage/app/controllers/$className$Controller.scala
@@ -27,12 +27,12 @@ class $className$Controller @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm($className$Page, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/.g8/datePage/app/controllers/$className$Controller.scala
+++ b/.g8/datePage/app/controllers/$className$Controller.scala
@@ -27,12 +27,12 @@ class $className$Controller @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm($className$Page, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/.g8/intPage/app/controllers/$className$Controller.scala
+++ b/.g8/intPage/app/controllers/$className$Controller.scala
@@ -27,12 +27,12 @@ class $className$Controller @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm($className$Page, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/.g8/multipleQuestionsPage/app/controllers/$className$Controller.scala
+++ b/.g8/multipleQuestionsPage/app/controllers/$className$Controller.scala
@@ -27,12 +27,12 @@ class $className$Controller @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm($className$Page, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/.g8/radioButtonPage/app/controllers/$className$Controller.scala
+++ b/.g8/radioButtonPage/app/controllers/$className$Controller.scala
@@ -27,12 +27,12 @@ class $className$Controller @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm($className$Page, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/.g8/stringPage/app/controllers/$className$Controller.scala
+++ b/.g8/stringPage/app/controllers/$className$Controller.scala
@@ -27,12 +27,12 @@ class $className$Controller @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm($className$Page, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/.g8/yesNoPage/app/controllers/$className$Controller.scala
+++ b/.g8/yesNoPage/app/controllers/$className$Controller.scala
@@ -27,12 +27,12 @@ class $className$Controller @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm($className$Page, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/app/connectors/emcsTfe/GetMovementConnector.scala
+++ b/app/connectors/emcsTfe/GetMovementConnector.scala
@@ -32,8 +32,8 @@ class GetMovementConnector @Inject()(val http: HttpClient,
   override implicit val reads: Reads[GetMovementResponse] = GetMovementResponse.reads
 
   lazy val baseUrl: String = config.emcsTfeBaseUrl
-  def getMovement(exciseRegistrationNumber: String, arc: String)
+  def getMovement(exciseRegistrationNumber: String, arc: String, forceFetchNew: Boolean)
                  (implicit headerCarrier: HeaderCarrier, executionContext: ExecutionContext): Future[Either[ErrorResponse, GetMovementResponse]] =
-    get(s"$baseUrl/movement/$exciseRegistrationNumber/$arc?forceFetchNew=true")
+    get(s"$baseUrl/movement/$exciseRegistrationNumber/$arc?forceFetchNew=$forceFetchNew")
 
 }

--- a/app/controllers/AcceptMovementController.scala
+++ b/app/controllers/AcceptMovementController.scala
@@ -44,12 +44,12 @@ class AcceptMovementController @Inject()(
                                         ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm(AcceptMovementPage, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/app/controllers/AddMoreInformationController.scala
+++ b/app/controllers/AddMoreInformationController.scala
@@ -93,7 +93,7 @@ class AddMoreInformationController @Inject()(
                          arc: String,
                          yesNoPage: QuestionPage[Boolean],
                          submitAction: Call): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm(yesNoPage, formProvider(yesNoPage)), yesNoPage, submitAction))
     }
 
@@ -103,7 +103,7 @@ class AddMoreInformationController @Inject()(
                        infoPage: QuestionPage[Option[String]],
                        submitAction: Call,
                        mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider(yesNoPage).bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, yesNoPage, submitAction))),

--- a/app/controllers/AddedItemsController.scala
+++ b/app/controllers/AddedItemsController.scala
@@ -51,7 +51,7 @@ class AddedItemsController @Inject()(
                                     ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withAddedItems(ern, arc) {
         getCnCodeInformationService.getCnCodeInformationWithListItems(_).flatMap {
           serviceResult =>
@@ -62,7 +62,7 @@ class AddedItemsController @Inject()(
     }
 
   def onSubmit(ern: String, arc: String): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
 
       val isPartiallyRefused = request.userAnswers.get(AcceptMovementPage).contains(PartiallyRefused)
 

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -52,7 +52,7 @@ class CheckYourAnswersController @Inject()(override val messagesApi: MessagesApi
                                           ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithUpToDateMovementAsync(ern, arc) { implicit request =>
       withAllCompletedItemsAsync() {
         items =>
           val formattedAnswersFuture: Future[Seq[(String, SummaryList)]] = {
@@ -92,7 +92,7 @@ class CheckYourAnswersController @Inject()(override val messagesApi: MessagesApi
     }
 
   def onSubmit(ern: String, arc: String): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithUpToDateMovementAsync(ern, arc) { implicit request =>
       submitReportOfReceiptService.submit(ern, arc).flatMap { response =>
 
         deleteDraftAndSetConfirmationFlow(request.internalId, request.ern, request.arc, response.receipt).map { _ =>

--- a/app/controllers/CheckYourAnswersItemController.scala
+++ b/app/controllers/CheckYourAnswersItemController.scala
@@ -44,7 +44,7 @@ class CheckYourAnswersItemController @Inject()(
                                           ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, idx: Int): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withItemAsync(idx) {
         item =>
           getCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item)).map {
@@ -61,7 +61,7 @@ class CheckYourAnswersItemController @Inject()(
     }
 
   def onSubmit(ern: String, arc: String, idx: Int): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withItemAsync(idx) {
         _ =>
           saveAndRedirect(CheckAnswersItemPage(idx), true, request.userAnswers, NormalMode)

--- a/app/controllers/ConfirmationController.scala
+++ b/app/controllers/ConfirmationController.scala
@@ -40,7 +40,7 @@ class ConfirmationController @Inject()(
                                       ) extends FrontendBaseController with I18nSupport with AuthActionHelper with Logging {
 
   def onPageLoad(ern: String, arc: String): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       request.userAnswers.get(ConfirmationPage) match {
         case Some(reference) =>
           Ok(view(reference))

--- a/app/controllers/DateOfArrivalController.scala
+++ b/app/controllers/DateOfArrivalController.scala
@@ -44,12 +44,12 @@ class DateOfArrivalController @Inject()(
                                        ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithUpToDateMovement(ern, arc) { implicit request =>
       Ok(view(fillForm(DateOfArrivalPage, formProvider(request.movementDetails.dateOfDispatch)), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithUpToDateMovementAsync(ern, arc) { implicit request =>
       formProvider(request.movementDetails.dateOfDispatch).bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/app/controllers/HowMuchIsWrongController.scala
+++ b/app/controllers/HowMuchIsWrongController.scala
@@ -45,12 +45,12 @@ class HowMuchIsWrongController @Inject()(
                                         ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm(HowMuchIsWrongPage, formProvider()), mode))
     }
 
   def onSubmit(ern: String, arc: String, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -39,7 +39,7 @@ class IndexController @Inject()(override val messagesApi: MessagesApi,
                                 view: ContinueDraftView) extends BaseController {
 
   def onPageLoad(ern: String, arc: String): Action[AnyContent] =
-    (authAction(ern, arc) andThen withMovement(arc) andThen getData).async { implicit request =>
+    (authAction(ern, arc) andThen withMovement.fromCache(arc) andThen getData).async { implicit request =>
       request.userAnswers match {
         case Some(ans) if ans.get(ConfirmationPage).isDefined =>
           initialiseAndRedirect(UserAnswers(request.internalId, request.ern, request.arc))
@@ -51,7 +51,7 @@ class IndexController @Inject()(override val messagesApi: MessagesApi,
     }
 
   def onSubmit(ern: String, arc: String): Action[AnyContent] =
-    (authAction(ern, arc) andThen withMovement(arc) andThen getData).async { implicit request =>
+    (authAction(ern, arc) andThen withMovement.fromCache(arc) andThen getData).async { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, routes.IndexController.onSubmit(ern, arc)))),

--- a/app/controllers/ItemDetailsController.scala
+++ b/app/controllers/ItemDetailsController.scala
@@ -43,7 +43,7 @@ class ItemDetailsController @Inject()(
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, idx: Int): Action[AnyContent] = {
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithUpToDateMovementAsync(ern, arc) { implicit request =>
       request.movementDetails.item(idx) match {
         case Some(item) =>
           getPackagingTypesService.getPackagingTypes(Seq(item)).flatMap {

--- a/app/controllers/ItemShortageOrExcessController.scala
+++ b/app/controllers/ItemShortageOrExcessController.scala
@@ -52,7 +52,7 @@ class ItemShortageOrExcessController @Inject()(
                                               ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withItemAsync(idx) { item =>
         getCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item)).map {
           serviceResult =>
@@ -63,7 +63,7 @@ class ItemShortageOrExcessController @Inject()(
     }
 
   def onSubmit(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withItemAsync(idx) { item =>
         getCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item)).flatMap {
           serviceResult =>

--- a/app/controllers/MoreInformationController.scala
+++ b/app/controllers/MoreInformationController.scala
@@ -90,7 +90,7 @@ class MoreInformationController @Inject()(
       routes.MoreInformationController.submitItemDamageInformation(ern, arc, idx, mode), mode)
 
   private def onPageLoad(ern: String, arc: String, page: QuestionPage[Option[String]], action: Call): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(fillForm(page, formProvider(page)), page, action))
     }
 
@@ -100,7 +100,7 @@ class MoreInformationController @Inject()(
                        yesNoPage: QuestionPage[Boolean],
                        action: Call,
                        mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider(page).bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, page, action))),

--- a/app/controllers/OtherInformationController.scala
+++ b/app/controllers/OtherInformationController.scala
@@ -61,12 +61,12 @@ class OtherInformationController @Inject()(
     onSubmit(ItemOtherInformationPage(idx), ern, arc, routes.OtherInformationController.submitItemOtherInformation(ern, arc, idx, mode), mode)
 
   private def onPageLoad(page: QuestionPage[String], ern: String, arc: String, action: Call): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(page, fillForm(page, formProvider(Some(page))), action))
     }
 
   private def onSubmit(page: QuestionPage[String], ern: String, arc: String, action: Call, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request: DataRequest[_] =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request: DataRequest[_] =>
       submitAndTrimWhitespaceFromTextarea[String](Some(page), formProvider)(
         formWithErrors => Future.successful(BadRequest(view(page, formWithErrors, action)))
       )(

--- a/app/controllers/RefusedAmountController.scala
+++ b/app/controllers/RefusedAmountController.scala
@@ -44,7 +44,7 @@ class RefusedAmountController @Inject()(
                                        ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withItemAsync(idx) { item =>
         getCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item)).map {
           serviceResult =>
@@ -60,7 +60,7 @@ class RefusedAmountController @Inject()(
     }
 
   def onSubmit(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withItemAsync(idx) { item =>
         val shortageAmount = request.userAnswers.get(ItemShortageOrExcessPage(item.itemUniqueReference)).flatMap(_.shortageAmount)
         formProvider(item.quantity, shortageAmount).bindFromRequest().fold(

--- a/app/controllers/RefusingAnyAmountOfItemController.scala
+++ b/app/controllers/RefusingAnyAmountOfItemController.scala
@@ -42,7 +42,7 @@ class RefusingAnyAmountOfItemController @Inject()(override val messagesApi: Mess
                                                   view: RefusingAnyAmountOfItemView) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(
         form = fillForm(RefusingAnyAmountOfItemPage(idx), formProvider()),
         action = routes.RefusingAnyAmountOfItemController.onSubmit(ern, arc, idx, mode)
@@ -50,7 +50,7 @@ class RefusingAnyAmountOfItemController @Inject()(override val messagesApi: Mess
     }
 
   def onSubmit(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider().bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, routes.RefusingAnyAmountOfItemController.onSubmit(ern, arc, idx, mode)))),

--- a/app/controllers/RemoveItemController.scala
+++ b/app/controllers/RemoveItemController.scala
@@ -46,7 +46,7 @@ class RemoveItemController @Inject()(
   def onPageLoad(ern: String,
                          arc: String,
                          idx: Int): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       withItem(idx) {
         _ => Ok(view(
           form = formProvider(RemoveItemPage(idx)),
@@ -59,7 +59,7 @@ class RemoveItemController @Inject()(
   def onSubmit(ern: String,
                        arc: String,
                        idx: Int): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withItemAsync(idx) {
         _ =>
         formProvider(RemoveItemPage(idx)).bindFromRequest().fold(

--- a/app/controllers/SelectItemsController.scala
+++ b/app/controllers/SelectItemsController.scala
@@ -45,7 +45,7 @@ class SelectItemsController @Inject()(override val messagesApi: MessagesApi,
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithUpToDateMovementAsync(ern, arc) { implicit request =>
       val filteredItems: Seq[MovementItem] = getFilteredItems(request)
       if (filteredItems.isEmpty) {
         Future.successful(Redirect(routes.AddedItemsController.onPageLoad(ern, arc)))
@@ -59,7 +59,7 @@ class SelectItemsController @Inject()(override val messagesApi: MessagesApi,
     }
 
   def addItemToList(ern: String, arc: String, itemUniqueReference: Int): Action[AnyContent] =
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       // remove any previously entered data before adding an item to the list
       val newUserAnswers = request.userAnswers.removeItem(itemUniqueReference)
       saveAndRedirect(SelectItemsPage(itemUniqueReference), itemUniqueReference, newUserAnswers, NormalMode)

--- a/app/controllers/WrongWithMovementController.scala
+++ b/app/controllers/WrongWithMovementController.scala
@@ -49,7 +49,7 @@ class WrongWithMovementController @Inject()(
     onPageLoad(WrongWithMovementPage, ern, arc, routes.WrongWithMovementController.submitWrongWithMovement(ern, arc, mode))
 
   def submitWrongWithMovement(ern: String, arc: String, mode: Mode): Action[AnyContent] = {
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider(WrongWithMovementPage).bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(
@@ -100,7 +100,7 @@ class WrongWithMovementController @Inject()(
     onPageLoad(WrongWithItemPage(idx), ern, arc, routes.WrongWithMovementController.submitWrongWithItem(ern, arc, idx, mode))
 
   def submitWrongWithItem(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] = {
-    authorisedDataRequestAsync(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       formProvider(WrongWithItemPage(idx)).bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(
@@ -145,7 +145,7 @@ class WrongWithMovementController @Inject()(
                          ern: String,
                          arc: String,
                          action: Call): Action[AnyContent] =
-    authorisedDataRequest(ern, arc) { implicit request =>
+    authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
       Ok(view(page, fillForm(page, formProvider(page)), action))
     }
 }

--- a/app/controllers/actions/MovementItemAction.scala
+++ b/app/controllers/actions/MovementItemAction.scala
@@ -30,7 +30,7 @@ class MovementActionImpl @Inject()(getMovementConnector: GetMovementConnector,
                                    errorHandler: ErrorHandler)
                                   (implicit ec: ExecutionContext) extends MovementAction {
 
-  override def apply(arc: String): ActionRefiner[UserRequest, MovementRequest] = new ActionRefiner[UserRequest, MovementRequest] {
+  override def apply(arc: String, forceFetchNew: Boolean): ActionRefiner[UserRequest, MovementRequest] = new ActionRefiner[UserRequest, MovementRequest] {
 
     override def executionContext: ExecutionContext = ec
 
@@ -38,7 +38,7 @@ class MovementActionImpl @Inject()(getMovementConnector: GetMovementConnector,
 
       implicit val hc = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-      getMovementConnector.getMovement(request.ern, arc).map {
+      getMovementConnector.getMovement(request.ern, arc, forceFetchNew).map {
         case Left(_) =>
           Left(Redirect(controllers.error.routes.ErrorController.unauthorised()))
         case Right(movementDetails) =>
@@ -49,5 +49,7 @@ class MovementActionImpl @Inject()(getMovementConnector: GetMovementConnector,
 }
 
 trait MovementAction {
-  def apply(arc: String): ActionRefiner[UserRequest, MovementRequest]
+  def apply(arc: String, forceFetchNew: Boolean): ActionRefiner[UserRequest, MovementRequest]
+  def upToDate(arc: String): ActionRefiner[UserRequest, MovementRequest] = apply(arc, forceFetchNew = true)
+  def fromCache(arc: String): ActionRefiner[UserRequest, MovementRequest] = apply(arc, forceFetchNew = false)
 }

--- a/app/controllers/actions/UserAllowListAction.scala
+++ b/app/controllers/actions/UserAllowListAction.scala
@@ -18,7 +18,6 @@ package controllers.actions
 
 import config.AppConfig
 import connectors.userAllowList.UserAllowListConnector
-import controllers.routes
 import featureswitch.core.config.{FeatureSwitching, UserAllowList}
 import handlers.ErrorHandler
 import models.requests.{CheckUserAllowListRequest, UserRequest}

--- a/app/services/AuditingService.scala
+++ b/app/services/AuditingService.scala
@@ -17,13 +17,12 @@
 package services
 
 import config.AppConfig
+import models.audit.AuditModel
 import play.api.libs.json.{JsObject, JsValue, Json}
-import play.api.mvc.Request
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
-import models.audit.AuditModel
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
@@ -31,7 +30,7 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class AuditingService @Inject()(config: AppConfig, auditConnector: AuditConnector)(implicit ec: ExecutionContext) {
 
-  def audit(auditModel: AuditModel)(implicit hc: HeaderCarrier, request: Request[_]): Unit = {
+  def audit(auditModel: AuditModel)(implicit hc: HeaderCarrier): Unit = {
     val dataEvent = toExtendedDataEvent(config.appName, auditModel)
     auditConnector.sendExtendedEvent(dataEvent)
   }

--- a/it/connectors/GetMovementConnectorISpec.scala
+++ b/it/connectors/GetMovementConnectorISpec.scala
@@ -51,49 +51,49 @@ class GetMovementConnectorISpec  extends AnyFreeSpec
 
     val body = Json.toJson(getMovementResponseInputJson)
 
-    val url = s"/emcs-tfe/movement/ern/arc?forceFetchNew=true"
+    def url(forceFetchNew: Boolean): String = s"/emcs-tfe/movement/ern/arc?forceFetchNew=$forceFetchNew"
 
     "must return true when the server responds OK" in {
 
       server.stubFor(
-        get(urlEqualTo(url))
+        get(urlEqualTo(url(forceFetchNew = true)))
           .willReturn(aResponse().withStatus(OK).withBody(Json.stringify(body)))
       )
 
-      connector.getMovement(exciseRegistrationNumber, arc).futureValue mustBe Right(getMovementResponseModel)
+      connector.getMovement(exciseRegistrationNumber, arc, forceFetchNew = true).futureValue mustBe Right(getMovementResponseModel)
     }
 
     "must return false when the server responds NOT_FOUND" in {
 
       server.stubFor(
-        get(urlEqualTo(url))
+        get(urlEqualTo(url(forceFetchNew = false)))
           .withHeader(AUTHORIZATION, equalTo("token"))
           .willReturn(aResponse().withStatus(NOT_FOUND))
       )
 
-      connector.getMovement(exciseRegistrationNumber, arc).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+      connector.getMovement(exciseRegistrationNumber, arc, forceFetchNew = false).futureValue mustBe Left(UnexpectedDownstreamResponseError)
     }
 
     "must fail when the server responds with any other status" in {
 
       server.stubFor(
-        get(urlEqualTo(url))
+        get(urlEqualTo(url(forceFetchNew = true)))
           .withHeader(AUTHORIZATION, equalTo("token"))
           .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
       )
 
-      connector.getMovement(exciseRegistrationNumber, arc).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+      connector.getMovement(exciseRegistrationNumber, arc, forceFetchNew = true).futureValue mustBe Left(UnexpectedDownstreamResponseError)
     }
 
     "must fail when the connection fails" in {
 
       server.stubFor(
-        get(urlEqualTo(url))
+        get(urlEqualTo(url(forceFetchNew = true)))
           .withHeader(AUTHORIZATION, equalTo("token"))
           .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE))
       )
 
-      connector.getMovement(exciseRegistrationNumber, arc).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+      connector.getMovement(exciseRegistrationNumber, arc, forceFetchNew = true).futureValue mustBe Left(UnexpectedDownstreamResponseError)
     }
   }
 

--- a/test/connectors/emcsTfe/GetMovementConnectorSpec.scala
+++ b/test/connectors/emcsTfe/GetMovementConnectorSpec.scala
@@ -45,7 +45,7 @@ class GetMovementConnectorSpec extends SpecBase
 
         MockHttpClient.get(s"${appConfig.emcsTfeBaseUrl}/movement/ern/arc?forceFetchNew=true").returns(Future.successful(Right(getMovementResponseModel)))
 
-        connector.getMovement(exciseRegistrationNumber = "ern", arc = "arc").futureValue mustBe Right(getMovementResponseModel)
+        connector.getMovement(exciseRegistrationNumber = "ern", arc = "arc", forceFetchNew = true).futureValue mustBe Right(getMovementResponseModel)
       }
     }
 
@@ -53,9 +53,9 @@ class GetMovementConnectorSpec extends SpecBase
 
       "when downstream call fails" in {
 
-        MockHttpClient.get(s"${appConfig.emcsTfeBaseUrl}/movement/ern/arc?forceFetchNew=true").returns(Future.successful(Left(JsonValidationError)))
+        MockHttpClient.get(s"${appConfig.emcsTfeBaseUrl}/movement/ern/arc?forceFetchNew=false").returns(Future.successful(Left(JsonValidationError)))
 
-        connector.getMovement(exciseRegistrationNumber = "ern", arc = "arc").futureValue mustBe Left(JsonValidationError)
+        connector.getMovement(exciseRegistrationNumber = "ern", arc = "arc", forceFetchNew = false).futureValue mustBe Left(JsonValidationError)
       }
     }
   }

--- a/test/controllers/actions/FakeMovementAction.scala
+++ b/test/controllers/actions/FakeMovementAction.scala
@@ -24,7 +24,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class FakeMovementAction(movementData: GetMovementResponse) extends MovementAction {
 
-  override def apply(arc: String): ActionRefiner[UserRequest, MovementRequest] = new ActionRefiner[UserRequest, MovementRequest] {
+  override def apply(arc: String, forceFetchNew: Boolean): ActionRefiner[UserRequest, MovementRequest] = new ActionRefiner[UserRequest, MovementRequest] {
 
     override def refine[A](request: UserRequest[A]): Future[Either[Result, MovementRequest[A]]] =
       Future.successful(Right(MovementRequest(request, arc, movementData)))

--- a/test/mocks/connectors/MockGetMovementConnector.scala
+++ b/test/mocks/connectors/MockGetMovementConnector.scala
@@ -19,7 +19,7 @@ package mocks.connectors
 import connectors.emcsTfe.GetMovementConnector
 import models.response.ErrorResponse
 import models.response.emcsTfe.GetMovementResponse
-import org.scalamock.handlers.CallHandler4
+import org.scalamock.handlers.CallHandler5
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -32,8 +32,9 @@ trait MockGetMovementConnector extends MockFactory {
   object MockGetMovementConnector {
 
     def getMovement(ern: String,
-                    arc: String): CallHandler4[String, String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, GetMovementResponse]]] =
-      (mockGetMovementConnector.getMovement(_: String, _: String)(_: HeaderCarrier, _: ExecutionContext))
-        .expects(ern, arc, *, *)
+                    arc: String,
+                    forceFetchNew: Boolean): CallHandler5[String, String, Boolean, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, GetMovementResponse]]] =
+      (mockGetMovementConnector.getMovement(_: String, _: String, _: Boolean)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(ern, arc, forceFetchNew, *, *)
   }
 }

--- a/test/mocks/services/MockAuditingService.scala
+++ b/test/mocks/services/MockAuditingService.scala
@@ -17,8 +17,7 @@
 package mocks.services
 
 import models.audit.AuditModel
-import models.requests.DataRequest
-import org.scalamock.handlers.CallHandler3
+import org.scalamock.handlers.CallHandler2
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import services.AuditingService
@@ -29,9 +28,8 @@ trait MockAuditingService extends MockFactory with BeforeAndAfterEach {
   lazy val mockAuditingService: AuditingService = mock[AuditingService]
 
   object MockAuditingService {
-    def verifyAudit(auditModel: AuditModel)
-    : CallHandler3[AuditModel, HeaderCarrier,  DataRequest[_], Unit] =
-      (mockAuditingService.audit( _: AuditModel)(_: HeaderCarrier, _: DataRequest[_]))
-        .expects(*, *, *)
+    def verifyAudit(auditModel: AuditModel): CallHandler2[AuditModel, HeaderCarrier, Unit] =
+      (mockAuditingService.audit( _: AuditModel)(_: HeaderCarrier))
+        .expects(*, *)
   }
 }

--- a/test/views/auth/errors/InactiveEnrolmentViewSpec.scala
+++ b/test/views/auth/errors/InactiveEnrolmentViewSpec.scala
@@ -19,7 +19,6 @@ package views.auth.errors
 import base.ViewSpecBase
 import config.AppConfig
 import fixtures.messages.InactiveEnrolmentMessages
-import models.requests.DataRequest
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.i18n.Messages

--- a/test/views/auth/errors/NoEnrolmentViewSpec.scala
+++ b/test/views/auth/errors/NoEnrolmentViewSpec.scala
@@ -19,11 +19,9 @@ package views.auth.errors
 import base.ViewSpecBase
 import config.AppConfig
 import fixtures.messages.NoEnrolmentMessages
-import models.requests.DataRequest
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.i18n.Messages
-import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import views.html.auth.errors.NoEnrolmentView
 import views.{BaseSelectors, ViewBehaviours}

--- a/test/views/auth/errors/UnauthorisedViewSpec.scala
+++ b/test/views/auth/errors/UnauthorisedViewSpec.scala
@@ -17,9 +17,7 @@
 package views.auth.errors
 
 import base.ViewSpecBase
-import config.AppConfig
 import fixtures.messages.UnauthorisedMessages
-import models.requests.DataRequest
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.i18n.Messages


### PR DESCRIPTION
**Notes**:
- Refactoring the AuthActionHelper seemed like the best way to abstract this away from the controllers
- I'm not convinced by the helper method names, so if someone can suggest something more appropriate then I'm happy to change them 🙂 
- All the scaffolds default to using the cache rather than refreshing from ChRIS; so it will have to be an active decision when we want to ensure the movement data is up to date to change the controller authAction helper used. 
- Most Controllers methods use the cache for the data, with the exception of those which actually end up reference the movement data for information 