### PR TITLE
[ETFE-1332] Added ReferenceDataService

### DIFF
--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -36,17 +36,23 @@ trait BaseController extends FrontendBaseController with I18nSupport with Enumer
                  (implicit request: DataRequest[_], format: Format[A]): Form[A] =
     request.userAnswers.get(page).fold(form)(form.fill)
 
-  def withItem(idx: Int)(f: MovementItem => Result)(implicit request: DataRequest[_]): Result =
+  def withAllCompletedItemsAsync()(f: Seq[MovementItem] => Future[Result])(implicit request: DataRequest[_]): Future[Result] =
+    f(request.getAllCompletedItemDetails)
+
+  def withAddedItem(idx: Int)(f: MovementItem => Result)(implicit request: DataRequest[_]): Result =
     request.getItemDetails(idx) match {
       case Some(item) => f(item)
       case None => Redirect(routes.SelectItemsController.onPageLoad(request.ern, request.arc).url)
     }
 
-  def withAllCompletedItemsAsync()(f: Seq[MovementItem] => Future[Result])(implicit request: DataRequest[_]): Future[Result] =
-    f(request.getAllCompletedItemDetails)
-
-  def withItemAsync(idx: Int)(f: MovementItem => Future[Result])(implicit request: DataRequest[_]): Future[Result] =
+  def withAddedItemAsync(idx: Int)(f: MovementItem => Future[Result])(implicit request: DataRequest[_]): Future[Result] =
     request.getItemDetails(idx) match {
+      case Some(item) => f(item)
+      case None => Future.successful(Redirect(routes.SelectItemsController.onPageLoad(request.ern, request.arc).url))
+    }
+
+  def withMovementItemAsync(idx: Int)(f: MovementItem => Future[Result])(implicit request: DataRequest[_]): Future[Result] =
+    request.movementDetails.item(idx) match {
       case Some(item) => f(item)
       case None => Future.successful(Redirect(routes.SelectItemsController.onPageLoad(request.ern, request.arc).url))
     }

--- a/app/controllers/CheckYourAnswersItemController.scala
+++ b/app/controllers/CheckYourAnswersItemController.scala
@@ -40,7 +40,7 @@ class CheckYourAnswersItemController @Inject()(
 
   def onPageLoad(ern: String, arc: String, idx: Int): Action[AnyContent] =
     authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
-      withItemAsync(idx) {
+      withAddedItemAsync(idx) {
         _ =>
           saveAndRedirect(CheckAnswersItemPage(idx), true, request.userAnswers, NormalMode)
       }

--- a/app/controllers/ItemDetailsController.scala
+++ b/app/controllers/ItemDetailsController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import navigation.Navigator
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import services.{GetCnCodeInformationService, GetPackagingTypesService, GetWineOperationsService, UserAnswersService}
+import services.{UserAnswersService, ReferenceDataService}
 import views.html.ItemDetailsView
 
 import javax.inject.Inject
@@ -36,9 +36,7 @@ class ItemDetailsController @Inject()(
                                        override val getData: DataRetrievalAction,
                                        override val requireData: DataRequiredAction,
                                        val controllerComponents: MessagesControllerComponents,
-                                       getCnCodeInformationService: GetCnCodeInformationService,
-                                       getPackagingTypesService: GetPackagingTypesService,
-                                       getWineOperationsService: GetWineOperationsService,
+                                       referenceDataService: ReferenceDataService,
                                        view: ItemDetailsView
                                      ) extends BaseNavigationController with AuthActionHelper {
 
@@ -46,15 +44,12 @@ class ItemDetailsController @Inject()(
     authorisedDataRequestWithUpToDateMovementAsync(ern, arc) { implicit request =>
       request.movementDetails.item(idx) match {
         case Some(item) =>
-          getPackagingTypesService.getPackagingTypes(Seq(item)).flatMap {
-            getWineOperationsService.getWineOperations(_).flatMap {
-              getCnCodeInformationService.getCnCodeInformationWithMovementItems(_).map {
-                case (item, cnCodeInformation) :: Nil => Ok(view(item, cnCodeInformation))
-                case _ =>
-                  logger.warn(s"[onPageLoad] Problem retrieving reference data for item idx: $idx against ERN: $ern and ARC: $arc")
-                  Redirect(routes.SelectItemsController.onPageLoad(request.ern, request.arc).url)
-              }
-            }
+          referenceDataService.getMovementItemsWithReferenceData(Seq(item)).map {
+            case (item, cnCodeInformation) :: Nil =>
+              Ok(view(item, cnCodeInformation))
+            case _ =>
+              logger.warn(s"[onPageLoad] Problem retrieving reference data for item idx: $idx against ERN: $ern and ARC: $arc")
+              Redirect(routes.SelectItemsController.onPageLoad(request.ern, request.arc).url)
           }
         case None =>
           logger.warn(s"[onPageLoad] Unable to find item with idx: $idx against ERN: $ern and ARC: $arc")

--- a/app/controllers/ItemShortageOrExcessController.scala
+++ b/app/controllers/ItemShortageOrExcessController.scala
@@ -53,7 +53,7 @@ class ItemShortageOrExcessController @Inject()(
 
   def onPageLoad(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
     authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
-      withItemAsync(idx) { item =>
+      withAddedItemAsync(idx) { item =>
         getCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item)).map {
           serviceResult =>
             val unitOfMeasure = serviceResult.head._2.unitOfMeasureCode.toUnitOfMeasure
@@ -64,7 +64,7 @@ class ItemShortageOrExcessController @Inject()(
 
   def onSubmit(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
     authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
-      withItemAsync(idx) { item =>
+      withAddedItemAsync(idx) { item =>
         getCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item)).flatMap {
           serviceResult =>
             val unitOfMeasure = serviceResult.head._2.unitOfMeasureCode.toUnitOfMeasure

--- a/app/controllers/RefusedAmountController.scala
+++ b/app/controllers/RefusedAmountController.scala
@@ -45,7 +45,7 @@ class RefusedAmountController @Inject()(
 
   def onPageLoad(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
     authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
-      withItemAsync(idx) { item =>
+      withAddedItemAsync(idx) { item =>
         getCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item)).map {
           serviceResult =>
             val (item, cnCodeInformation) = serviceResult.head
@@ -64,7 +64,7 @@ class RefusedAmountController @Inject()(
 
   def onSubmit(ern: String, arc: String, idx: Int, mode: Mode): Action[AnyContent] =
     authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
-      withItemAsync(idx) { item =>
+      withAddedItemAsync(idx) { item =>
         val shortageAmount = request.userAnswers.get(ItemShortageOrExcessPage(item.itemUniqueReference)).flatMap(_.shortageAmount)
         formProvider(item.quantity, shortageAmount).bindFromRequest().fold(
           formWithErrors => {

--- a/app/controllers/RemoveItemController.scala
+++ b/app/controllers/RemoveItemController.scala
@@ -49,7 +49,7 @@ class RemoveItemController @Inject()(
                  idx: Int,
                  mode: Mode = NormalMode): Action[AnyContent] =
     authorisedDataRequestWithCachedMovement(ern, arc) { implicit request =>
-      withItem(idx) {
+      withAddedItem(idx) {
         _ => Ok(view(
           form = formProvider(RemoveItemPage(idx)),
           page = RemoveItemPage(idx),
@@ -63,7 +63,7 @@ class RemoveItemController @Inject()(
                idx: Int,
                mode: Mode = NormalMode): Action[AnyContent] =
     authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
-      withItemAsync(idx) {
+      withAddedItemAsync(idx) {
         _ =>
           formProvider(RemoveItemPage(idx)).bindFromRequest().fold(
             formWithErrors =>

--- a/app/controllers/SelectItemsController.scala
+++ b/app/controllers/SelectItemsController.scala
@@ -22,8 +22,8 @@ import models.requests.DataRequest
 import models.response.emcsTfe.MovementItem
 import navigation.Navigator
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import services.{GetCnCodeInformationService, GetPackagingTypesService, UserAnswersService}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.{ReferenceDataService, UserAnswersService}
 import views.html.SelectItemsView
 
 import javax.inject.Inject
@@ -38,38 +38,31 @@ class SelectItemsController @Inject()(override val messagesApi: MessagesApi,
                                       override val getData: DataRetrievalAction,
                                       override val requireData: DataRequiredAction,
                                       val controllerComponents: MessagesControllerComponents,
-                                      getCnCodeInformationService: GetCnCodeInformationService,
-                                      getPackagingTypesService: GetPackagingTypesService,
+                                      referenceDataService: ReferenceDataService,
                                       view: SelectItemsView
                                      ) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String): Action[AnyContent] =
     authorisedDataRequestWithUpToDateMovementAsync(ern, arc) { implicit request =>
-      val filteredItems: Seq[MovementItem] = getFilteredItems(request)
-      if (filteredItems.isEmpty) {
-        Future.successful(Redirect(routes.AddedItemsController.onPageLoad(ern, arc)))
-      } else {
-        getPackagingTypesService.getPackagingTypes(filteredItems).flatMap {
-          getCnCodeInformationService.getCnCodeInformationWithMovementItems(_).map {
-            serviceResult => Ok(view(serviceResult))
-          }
+      withFilteredItems { filteredItems =>
+        referenceDataService.getMovementItemsWithReferenceData(filteredItems).map { serviceResult =>
+          Ok(view(serviceResult))
         }
       }
     }
 
-  private[controllers] def getFilteredItems(implicit request: DataRequest[_]): Seq[MovementItem] = {
-    val userAnswersUniqueReferences = request.userAnswers.itemReferences
-    if (userAnswersUniqueReferences.isEmpty) {
-      request.movementDetails.items
+  private[controllers] def withFilteredItems(f: Seq[MovementItem] => Future[Result])(implicit request: DataRequest[_]): Future[Result] =
+    if (request.userAnswers.itemReferences.isEmpty) {
+      f(request.movementDetails.items)
     } else {
-      val completedItems: Seq[ItemModel] =
-        request.userAnswers.completedItems
-
-      request.movementDetails.items.filterNot {
-        movementDetailsItem =>
-          completedItems.exists(_.itemUniqueReference == movementDetailsItem.itemUniqueReference)
+      request.movementDetails.items.filterNot { movementDetailsItem =>
+        request.userAnswers.completedItems.exists(_.itemUniqueReference == movementDetailsItem.itemUniqueReference)
+      } match {
+        case filteredItems if filteredItems.nonEmpty =>
+          f(filteredItems)
+        case _ =>
+          Future.successful(Redirect(routes.AddedItemsController.onPageLoad(request.ern, request.arc)))
       }
     }
-  }
 
 }

--- a/app/services/ReferenceDataService.scala
+++ b/app/services/ReferenceDataService.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import com.google.inject.Inject
+import models.response.emcsTfe.MovementItem
+import models.response.referenceData.CnCodeInformation
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ReferenceDataService @Inject()(packagingTypesService: GetPackagingTypesService,
+                                     wineOperationsService: GetWineOperationsService,
+                                     cnCodeInformation: GetCnCodeInformationService) {
+  def getMovementItemsWithReferenceData(items: Seq[MovementItem])
+                                       (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[(MovementItem, CnCodeInformation)]] =
+    packagingTypesService.getPackagingTypes(items).flatMap {
+      wineOperationsService.getWineOperations(_).flatMap {
+        cnCodeInformation.getCnCodeInformationWithMovementItems(_)
+      }
+    }
+}

--- a/app/services/ReferenceDataService.scala
+++ b/app/services/ReferenceDataService.scala
@@ -38,20 +38,10 @@ class ReferenceDataService @Inject()(packagingTypesService: GetPackagingTypesSer
       }
     }
 
-  def itemsWithReferenceData(items: Seq[MovementItem])(f: Seq[(MovementItem, CnCodeInformation)] => Future[Result])
-                            (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result] =
-    packagingTypesService.getPackagingTypes(items).flatMap {
-      wineOperationsService.getWineOperations(_).flatMap {
-        cnCodeInformation.getCnCodeInformationWithMovementItems(_).flatMap {
-          f(_)
-        }
-      }
-    }
-
   def itemWithReferenceData(item: MovementItem)(f: (MovementItem, CnCodeInformation) => Future[Result])
                            (implicit hc: HeaderCarrier, ec: ExecutionContext, request: DataRequest[_]): Future[Result] =
     getMovementItemsWithReferenceData(Seq(item)).flatMap {
-      case (item, cnCodeInformation) +: Nil =>
+      case (item, cnCodeInformation) :: Nil =>
         f(item, cnCodeInformation)
       case _ =>
         logger.warn(s"[itemWithReferenceData] Problem retrieving reference data for" +

--- a/test/controllers/AddItemMoreInformationControllerSpec.scala
+++ b/test/controllers/AddItemMoreInformationControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.AddMoreInformationFormProvider
-import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockUserAnswersService}
+import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockGetWineOperationsService, MockUserAnswersService}
 import models.{NormalMode, UserAnswers}
 import models.ReferenceDataUnitOfMeasure.`1`
 import models.response.referenceData.CnCodeInformation
@@ -28,7 +28,7 @@ import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.{GetCnCodeInformationService, GetPackagingTypesService, UserAnswersService}
+import services.{GetCnCodeInformationService, GetPackagingTypesService, GetWineOperationsService, UserAnswersService}
 import views.html.AddItemMoreInformationView
 
 import scala.concurrent.Future
@@ -36,7 +36,8 @@ import scala.concurrent.Future
 class AddItemMoreInformationControllerSpec extends SpecBase
   with MockGetCnCodeInformationService
   with MockUserAnswersService
-  with MockGetPackagingTypesService {
+  with MockGetPackagingTypesService
+  with MockGetWineOperationsService {
 
 
   class Fixture(answers: Option[UserAnswers] = Some(emptyUserAnswers)) {
@@ -44,6 +45,7 @@ class AddItemMoreInformationControllerSpec extends SpecBase
       .overrides(
         bind[GetCnCodeInformationService].toInstance(mockGetCnCodeInformationService),
         bind[GetPackagingTypesService].toInstance(mockGetPackagingTypesService),
+        bind[GetWineOperationsService].toInstance(mockGetWineOperationsService),
         bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
         bind[UserAnswersService].toInstance(mockUserAnswersService)
       ).build()
@@ -78,6 +80,8 @@ class AddItemMoreInformationControllerSpec extends SpecBase
             (itemWithPackaging, CnCodeInformation("", "", `1`))
           )))
 
+          MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
+
           val request = FakeRequest(GET, url)
 
           val result = route(application, request).value
@@ -101,6 +105,8 @@ class AddItemMoreInformationControllerSpec extends SpecBase
           MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(itemWithPackaging)).returns(Future.successful(Seq(
             (itemWithPackaging, CnCodeInformation("", "", `1`))
           )))
+
+          MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
 
           val request = FakeRequest(GET, url)
 
@@ -154,6 +160,8 @@ class AddItemMoreInformationControllerSpec extends SpecBase
           MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(itemWithPackaging)).returns(Future.successful(Seq(
             (itemWithPackaging, CnCodeInformation("", "", `1`))
           )))
+
+          MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
 
           val request = FakeRequest(POST, url).withFormUrlEncodedBody(("value", ""))
 

--- a/test/controllers/CheckYourAnswersItemControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersItemControllerSpec.scala
@@ -73,7 +73,7 @@ class CheckYourAnswersItemControllerSpec extends SpecBase
         }
       }
 
-      "must redirect to Journey Recovery for a POST if no existing data is found" in {
+      "must redirect to SelectItemsController for a GET if no items are added" in {
 
         val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(bind[GetCnCodeInformationService].toInstance(mockGetCnCodeInformationService))

--- a/test/controllers/DetailsSelectItemControllerSpec.scala
+++ b/test/controllers/DetailsSelectItemControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.DetailsSelectItemFormProvider
-import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockUserAnswersService}
+import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockGetWineOperationsService, MockUserAnswersService}
 import models.AcceptMovement.{PartiallyRefused, Unsatisfactory}
 import models.{NormalMode, UserAnswers}
 import models.ReferenceDataUnitOfMeasure.`1`
@@ -29,7 +29,7 @@ import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.{GetCnCodeInformationService, GetPackagingTypesService, UserAnswersService}
+import services.{GetCnCodeInformationService, GetPackagingTypesService, GetWineOperationsService, UserAnswersService}
 import views.html.DetailsSelectItemView
 
 import scala.concurrent.Future
@@ -37,13 +37,15 @@ import scala.concurrent.Future
 class DetailsSelectItemControllerSpec extends SpecBase
   with MockGetCnCodeInformationService
   with MockUserAnswersService
-  with MockGetPackagingTypesService {
+  with MockGetPackagingTypesService
+  with MockGetWineOperationsService {
 
   class Fixture(val userAnswers: Option[UserAnswers] = Some(emptyUserAnswers)) {
     val application = applicationBuilder(userAnswers)
       .overrides(
         bind[GetCnCodeInformationService].toInstance(mockGetCnCodeInformationService),
         bind[GetPackagingTypesService].toInstance(mockGetPackagingTypesService),
+        bind[GetWineOperationsService].toInstance(mockGetWineOperationsService),
         bind[UserAnswersService].toInstance(mockUserAnswersService)
       ).build()
 
@@ -72,6 +74,8 @@ class DetailsSelectItemControllerSpec extends SpecBase
           (item1, CnCodeInformation("", "", `1`))
         )))
 
+        MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
+
         val request = FakeRequest(GET, detailsSelectItemRoute)
         val result = route(application, request).value
 
@@ -97,6 +101,7 @@ class DetailsSelectItemControllerSpec extends SpecBase
           )))
 
           MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item1)).returns(Future.successful(Seq.empty))
+          MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
 
           val request = FakeRequest(GET, detailsSelectItemRoute)
           val result = route(application, request).value
@@ -177,6 +182,8 @@ class DetailsSelectItemControllerSpec extends SpecBase
         MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item1)).returns(Future.successful(Seq(
           (item1, CnCodeInformation("", "", `1`))
         )))
+
+        MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
 
         val boundForm = form.bind(Map("value" -> ""))
         val request = FakeRequest(POST, detailsSelectItemRoute).withFormUrlEncodedBody(("value", ""))

--- a/test/controllers/ItemMoreInformationControllerSpec.scala
+++ b/test/controllers/ItemMoreInformationControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.MoreInformationFormProvider
-import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockUserAnswersService}
+import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockGetWineOperationsService, MockUserAnswersService}
 import models.ReferenceDataUnitOfMeasure.`1`
 import models.response.referenceData.CnCodeInformation
 import models.{NormalMode, UserAnswers}
@@ -28,7 +28,7 @@ import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.{GetCnCodeInformationService, GetPackagingTypesService, UserAnswersService}
+import services.{GetCnCodeInformationService, GetPackagingTypesService, GetWineOperationsService, UserAnswersService}
 import views.html.ItemMoreInformationView
 
 import scala.concurrent.Future
@@ -36,13 +36,15 @@ import scala.concurrent.Future
 class ItemMoreInformationControllerSpec extends SpecBase
   with MockGetCnCodeInformationService
   with MockUserAnswersService
-  with MockGetPackagingTypesService {
+  with MockGetPackagingTypesService
+  with MockGetWineOperationsService {
 
   class Fixture(val answers: Option[UserAnswers] = Some(emptyUserAnswers.set(SelectItemsPage(item1.itemUniqueReference), item1.itemUniqueReference))) {
     val application = applicationBuilder(userAnswers = answers)
       .overrides(
         bind[GetCnCodeInformationService].toInstance(mockGetCnCodeInformationService),
         bind[GetPackagingTypesService].toInstance(mockGetPackagingTypesService),
+        bind[GetWineOperationsService].toInstance(mockGetWineOperationsService),
         bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
         bind[UserAnswersService].toInstance(mockUserAnswersService)
       ).build()
@@ -78,6 +80,8 @@ class ItemMoreInformationControllerSpec extends SpecBase
             (itemWithPackaging, cnCodeInfo)
           )))
 
+          MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
+
           val request = FakeRequest(GET, url)
 
           val result = route(application, request).value
@@ -97,6 +101,8 @@ class ItemMoreInformationControllerSpec extends SpecBase
           MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(itemWithPackaging)).returns(Future.successful(Seq(
             (itemWithPackaging, cnCodeInfo)
           )))
+
+          MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
 
           val request = FakeRequest(GET, url)
 
@@ -146,6 +152,8 @@ class ItemMoreInformationControllerSpec extends SpecBase
           MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(itemWithPackaging)).returns(Future.successful(Seq(
             (itemWithPackaging, cnCodeInfo)
           )))
+
+          MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
 
           val request = FakeRequest(POST, url).withFormUrlEncodedBody(("more-information", "<>"))
 

--- a/test/controllers/ItemMoreInformationControllerSpec.scala
+++ b/test/controllers/ItemMoreInformationControllerSpec.scala
@@ -23,7 +23,7 @@ import models.ReferenceDataUnitOfMeasure.`1`
 import models.response.referenceData.CnCodeInformation
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
-import pages.unsatisfactory.individualItems.{AddItemDamageInformationPage, ItemDamageInformationPage}
+import pages.unsatisfactory.individualItems.{AddItemDamageInformationPage, ItemDamageInformationPage, SelectItemsPage}
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -38,7 +38,7 @@ class ItemMoreInformationControllerSpec extends SpecBase
   with MockUserAnswersService
   with MockGetPackagingTypesService {
 
-  class Fixture(answers: Option[UserAnswers] = Some(emptyUserAnswers)) {
+  class Fixture(val answers: Option[UserAnswers] = Some(emptyUserAnswers.set(SelectItemsPage(item1.itemUniqueReference), item1.itemUniqueReference))) {
     val application = applicationBuilder(userAnswers = answers)
       .overrides(
         bind[GetCnCodeInformationService].toInstance(mockGetCnCodeInformationService),
@@ -86,7 +86,11 @@ class ItemMoreInformationControllerSpec extends SpecBase
           contentAsString(result) mustEqual view(form, page, submitAction, itemWithPackaging, cnCodeInfo)(dataRequest(request), messages(application)).toString
         }
 
-        "must populate the view correctly on a GET when the question has previously been answered" in new Fixture(Some(emptyUserAnswers.set(page, Some("answer")))) {
+        "must populate the view correctly on a GET when the question has previously been answered" in new Fixture(Some(
+          emptyUserAnswers
+            .set(SelectItemsPage(item1.itemUniqueReference), item1.itemUniqueReference)
+            .set(page, Some("answer"))
+        )) {
 
           MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(itemWithPackaging)))
 
@@ -104,7 +108,7 @@ class ItemMoreInformationControllerSpec extends SpecBase
 
         "must redirect to the next page when valid data is submitted" in new Fixture() {
 
-          val updatedAnswers = emptyUserAnswers
+          val updatedAnswers = answers.get
             .set(yesNoPage, true)
             .set(page, Some("answer"))
 
@@ -120,7 +124,7 @@ class ItemMoreInformationControllerSpec extends SpecBase
 
         "must redirect to the next page when NO data is submitted" in new Fixture() {
 
-          val updatedAnswers = emptyUserAnswers
+          val updatedAnswers = answers.get
             .set(yesNoPage, false)
             .set(page, None)
 

--- a/test/controllers/RefusingAnyAmountOfItemControllerSpec.scala
+++ b/test/controllers/RefusingAnyAmountOfItemControllerSpec.scala
@@ -65,7 +65,9 @@ class RefusingAnyAmountOfItemControllerSpec extends SpecBase with MockGetCnCodeI
 
   "RefusingAnyAmountOfItem Controller" - {
 
-    "must return OK and the correct view for a GET" in new Fixture() {
+    "must return OK and the correct view for a GET" in new Fixture(
+      Some(emptyUserAnswers.set(SelectItemsPage(1), 1))
+    ) {
 
       MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(item1)))
       MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
@@ -80,7 +82,9 @@ class RefusingAnyAmountOfItemControllerSpec extends SpecBase with MockGetCnCodeI
     }
 
     "must populate the view correctly on a GET when the question has previously been answered" in new Fixture(
-      Some(emptyUserAnswers.set(RefusingAnyAmountOfItemPage(1), true))
+      Some(emptyUserAnswers
+        .set(SelectItemsPage(1), 1)
+        .set(RefusingAnyAmountOfItemPage(1), true))
     ) {
 
       MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(item1)))
@@ -98,7 +102,10 @@ class RefusingAnyAmountOfItemControllerSpec extends SpecBase with MockGetCnCodeI
     "must redirect to the next page when valid data is submitted" - {
 
       "and delete the rest of the answers when the input answer isn't the same as the current answer" in new Fixture(
-        Some(emptyUserAnswers.set(RefusingAnyAmountOfItemPage(1), false))
+        Some(emptyUserAnswers
+          .set(SelectItemsPage(1), 1)
+          .set(RefusingAnyAmountOfItemPage(1), false)
+        )
       ) {
 
         val updatedAnswers = emptyUserAnswers
@@ -116,7 +123,10 @@ class RefusingAnyAmountOfItemControllerSpec extends SpecBase with MockGetCnCodeI
       }
 
       "and not delete the rest of the answers when the input answer is the same as the current answer" in new Fixture(
-        Some(emptyUserAnswers.set(RefusingAnyAmountOfItemPage(1), true))
+        Some(emptyUserAnswers
+          .set(SelectItemsPage(1), 1)
+          .set(RefusingAnyAmountOfItemPage(1), true)
+        )
       ) {
 
         MockUserAnswersService.set().never()
@@ -134,33 +144,17 @@ class RefusingAnyAmountOfItemControllerSpec extends SpecBase with MockGetCnCodeI
 
       "when the item doesn't exist in UserAnswers" in new Fixture() {
 
-        MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
-        MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(item1)))
-        MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item1)).returns(Future.successful(Seq.empty))
-
         val request = FakeRequest(GET, refusingAnyAmountOfItemRoute)
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual routes.SelectItemsController.onPageLoad(testErn, testArc).url
       }
-
-      "when the call to get CN information returned no data" in new Fixture() {
-
-        MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(item1)))
-        MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))
-        MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(item1)).returns(Future.successful(Seq.empty))
-
-        val request = FakeRequest(GET, refusingAnyAmountOfItemRoute)
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual routes.SelectItemsController.onPageLoad(testErn, testArc).url
-      }
-
     }
 
-    "must return a Bad Request and errors when invalid data is submitted" in new Fixture() {
+    "must return a Bad Request and errors when invalid data is submitted" in new Fixture(
+      Some(emptyUserAnswers.set(SelectItemsPage(1), 1))
+    ) {
 
       MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(item1)))
       MockGetWineOperationsService.getWineOperations(Seq(item1)).returns(Future.successful(Seq(item1)))

--- a/test/controllers/SelectItemsControllerSpec.scala
+++ b/test/controllers/SelectItemsControllerSpec.scala
@@ -132,12 +132,12 @@ class SelectItemsControllerSpec extends SpecBase
             .set(SelectItemsPage(2), 2)
             .set(WrongWithItemPage(2), Set[WrongWithMovement](Damaged))
             .set(AddItemDamageInformationPage(2), false)
-          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1, item2)
+          controller.incompleteItems()(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1, item2)
         }
 
         "when nothing has been selected yet" in {
           val userAnswers = emptyUserAnswers
-          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1, item2)
+          controller.incompleteItems()(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1, item2)
         }
       }
 
@@ -151,7 +151,7 @@ class SelectItemsControllerSpec extends SpecBase
             .set(SelectItemsPage(2), 2)
             .set(WrongWithItemPage(2), Set[WrongWithMovement](Damaged))
             .set(AddItemDamageInformationPage(2), false)
-          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item2)
+          controller.incompleteItems()(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item2)
         }
 
         "when the second item has checkAnswersItem = true" in {
@@ -163,7 +163,7 @@ class SelectItemsControllerSpec extends SpecBase
             .set(WrongWithItemPage(2), Set[WrongWithMovement](Damaged))
             .set(AddItemDamageInformationPage(2), false)
             .set(CheckAnswersItemPage(2), true)
-          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1)
+          controller.incompleteItems()(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1)
         }
 
         "when both items have checkAnswersItem = true" in {
@@ -176,7 +176,7 @@ class SelectItemsControllerSpec extends SpecBase
             .set(WrongWithItemPage(2), Set[WrongWithMovement](Damaged))
             .set(AddItemDamageInformationPage(2), false)
             .set(CheckAnswersItemPage(2), true)
-          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq()
+          controller.incompleteItems()(dataRequest(FakeRequest(), userAnswers)) mustBe Seq()
         }
       }
     }

--- a/test/controllers/SelectItemsControllerSpec.scala
+++ b/test/controllers/SelectItemsControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import base.SpecBase
-import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockUserAnswersService}
+import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockGetWineOperationsService, MockUserAnswersService}
 import models.ReferenceDataUnitOfMeasure.`1`
 import models.WrongWithMovement
 import models.WrongWithMovement.Damaged
@@ -27,7 +27,7 @@ import pages.unsatisfactory.individualItems.{AddItemDamageInformationPage, Check
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.{GetCnCodeInformationService, GetPackagingTypesService}
+import services.{GetCnCodeInformationService, GetPackagingTypesService, GetWineOperationsService}
 import utils.JsonOptionFormatter
 import views.html.SelectItemsView
 
@@ -37,6 +37,7 @@ class SelectItemsControllerSpec extends SpecBase
   with JsonOptionFormatter
   with MockUserAnswersService
   with MockGetCnCodeInformationService
+  with MockGetWineOperationsService
   with MockGetPackagingTypesService {
 
   lazy val loadListUrl: String = routes.SelectItemsController.onPageLoad(testErn, testArc).url
@@ -50,7 +51,8 @@ class SelectItemsControllerSpec extends SpecBase
         val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[GetCnCodeInformationService].toInstance(mockGetCnCodeInformationService),
-            bind[GetPackagingTypesService].toInstance(mockGetPackagingTypesService)
+            bind[GetPackagingTypesService].toInstance(mockGetPackagingTypesService),
+            bind[GetWineOperationsService].toInstance(mockGetWineOperationsService)
           )
           .build()
 
@@ -67,6 +69,8 @@ class SelectItemsControllerSpec extends SpecBase
           item1.copy(packaging = Seq(updatedBoxPackage)),
           item2.copy(packaging = Seq(updatedBoxPackage, updatedCratePackage))
         )))
+
+        MockGetWineOperationsService.getWineOperations(Seq(item1, item2)).returns(Future.successful(Seq(item1, item2)))
 
         running(application) {
           val request = FakeRequest(GET, loadListUrl)

--- a/test/controllers/SelectItemsControllerSpec.scala
+++ b/test/controllers/SelectItemsControllerSpec.scala
@@ -132,12 +132,12 @@ class SelectItemsControllerSpec extends SpecBase
             .set(SelectItemsPage(2), 2)
             .set(WrongWithItemPage(2), Set[WrongWithMovement](Damaged))
             .set(AddItemDamageInformationPage(2), false)
-          controller.getFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1, item2)
+          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1, item2)
         }
 
         "when nothing has been selected yet" in {
           val userAnswers = emptyUserAnswers
-          controller.getFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1, item2)
+          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1, item2)
         }
       }
 
@@ -151,7 +151,7 @@ class SelectItemsControllerSpec extends SpecBase
             .set(SelectItemsPage(2), 2)
             .set(WrongWithItemPage(2), Set[WrongWithMovement](Damaged))
             .set(AddItemDamageInformationPage(2), false)
-          controller.getFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item2)
+          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item2)
         }
 
         "when the second item has checkAnswersItem = true" in {
@@ -163,7 +163,7 @@ class SelectItemsControllerSpec extends SpecBase
             .set(WrongWithItemPage(2), Set[WrongWithMovement](Damaged))
             .set(AddItemDamageInformationPage(2), false)
             .set(CheckAnswersItemPage(2), true)
-          controller.getFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1)
+          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq(item1)
         }
 
         "when both items have checkAnswersItem = true" in {
@@ -176,7 +176,7 @@ class SelectItemsControllerSpec extends SpecBase
             .set(WrongWithItemPage(2), Set[WrongWithMovement](Damaged))
             .set(AddItemDamageInformationPage(2), false)
             .set(CheckAnswersItemPage(2), true)
-          controller.getFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq()
+          controller.withFilteredItems(dataRequest(FakeRequest(), userAnswers)) mustBe Seq()
         }
       }
     }

--- a/test/mocks/services/MockGetWineOperationsService.scala
+++ b/test/mocks/services/MockGetWineOperationsService.scala
@@ -34,7 +34,7 @@ trait MockGetWineOperationsService extends MockFactory {
       (mockGetWineOperationsService.getWineOperations(_: Seq[MovementItem])(_: HeaderCarrier))
         .expects(where {
           (_items: Seq[MovementItem], _) =>
-            _items.flatMap(_.packaging.map(_.typeOfPackage)) == items.flatMap(_.packaging.map(_.typeOfPackage))
+            _items.flatMap(_.wineProduct.map(_.wineOperations)) == items.flatMap(_.wineProduct.map(_.wineOperations))
         })
   }
 }

--- a/test/services/ReferenceDataServiceSpec.scala
+++ b/test/services/ReferenceDataServiceSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService, MockGetWineOperationsService}
+import models.ReferenceDataUnitOfMeasure.`1`
+import models.response.referenceData.CnCodeInformation
+import models.response.{PackagingTypesException, ReferenceDataException, WineOperationsException}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ReferenceDataServiceSpec extends SpecBase
+  with MockGetCnCodeInformationService
+  with MockGetWineOperationsService
+  with MockGetPackagingTypesService {
+
+  implicit val hc = HeaderCarrier()
+  implicit val ec = ExecutionContext.global
+
+  lazy val testService = new ReferenceDataService(mockGetPackagingTypesService, mockGetWineOperationsService, mockGetCnCodeInformationService)
+
+  val itemWithPackaging = item1.copy(packaging = Seq(boxPackage.copy(typeOfPackage = "Box")))
+  val itemWithPackagingAndWine = itemWithPackaging.copy(wineProduct = Some(wineProduct.copy(wineOperations = Some(Seq("Acidification")))))
+  val cnCodeInfo = CnCodeInformation("", "", `1`)
+
+  ".getMovementItemsWithReferenceData(items: Seq[MovementItem])" - {
+
+    "when packaging codes returns success" - {
+
+      "when wine operations returns success" - {
+
+        "when CnCodeInformation returns success" - {
+
+          "must return successful items with all information updated" in {
+
+            MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(itemWithPackaging)))
+            MockGetWineOperationsService.getWineOperations(Seq(itemWithPackaging)).returns(Future.successful(Seq(itemWithPackagingAndWine)))
+            MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(itemWithPackagingAndWine))
+              .returns(Future.successful(Seq(itemWithPackagingAndWine -> cnCodeInfo)))
+
+            await(testService.getMovementItemsWithReferenceData(Seq(item1))) mustBe Seq(itemWithPackagingAndWine -> cnCodeInfo)
+          }
+        }
+
+        "when CnCodeInformation returns failure" - {
+
+          "must return successful items with all information updated" in {
+
+            MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(itemWithPackaging)))
+            MockGetWineOperationsService.getWineOperations(Seq(itemWithPackaging)).returns(Future.successful(Seq(itemWithPackagingAndWine)))
+            MockGetCnCodeInformationService.getCnCodeInformationWithMovementItems(Seq(itemWithPackagingAndWine))
+              .returns(Future.failed(ReferenceDataException(s"Failed to match item with CN Code information")))
+
+            intercept[ReferenceDataException](await(testService.getMovementItemsWithReferenceData(Seq(item1)))).message mustBe
+              "Failed to match item with CN Code information"
+          }
+        }
+      }
+
+      "when wine operations returns failure" - {
+
+        "must return successful items with all information updated" in {
+
+          MockGetPackagingTypesService.getPackagingTypes(Seq(item1)).returns(Future.successful(Seq(itemWithPackaging)))
+          MockGetWineOperationsService.getWineOperations(Seq(itemWithPackaging))
+            .returns(Future.failed(WineOperationsException(s"Failed to retrieve wine operations from emcs-tfe-reference-data")))
+
+          intercept[WineOperationsException](await(testService.getMovementItemsWithReferenceData(Seq(item1)))).message mustBe
+            "Failed to retrieve wine operations from emcs-tfe-reference-data"
+        }
+      }
+    }
+
+    "when packaging codes returns failure" - {
+
+      "must return successful items with all information updated" in {
+
+        MockGetPackagingTypesService.getPackagingTypes(Seq(item1))
+          .returns(Future.failed(PackagingTypesException(s"Failed to retrieve packaging types from emcs-tfe-reference-data")))
+
+        intercept[PackagingTypesException](await(testService.getMovementItemsWithReferenceData(Seq(item1)))).message mustBe
+          "Failed to retrieve packaging types from emcs-tfe-reference-data"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Note:**
- Currently the same underlying mocks are used within the Controller tests. I'm going to refactor this, but I think it's worth reviewing this and merging first as it proves the orchestrator service behaves the same with the existing mocks.
- I'm continuing on a separate branch to introduce a `MockReferenceDataService` that can be used in all the controllers going forwards. 