### PR TITLE
[ETFE-1999] Updated views with large hints as per a11y recommendation

### DIFF
--- a/app/views/AddItemMoreInformationView.scala.html
+++ b/app/views/AddItemMoreInformationView.scala.html
@@ -28,7 +28,6 @@
         govukRadios: GovukRadios,
         govukButton: GovukButton,
         h1: components.h1,
-        h2: components.h2,
         continueOrExit: components.continueOrExit,
         itemDetails: components.itemDetailSection
 )
@@ -49,21 +48,19 @@
                 @govukErrorSummary(ErrorSummaryViewModel(form))
             }
 
-@h2((messages("arc.subHeading", request.arc)),"govuk-caption-l")
+            @h1(messages(AddMoreInformationHelper.headingKey(page), item.itemUniqueReference), Some(messages("arc.subHeading", request.arc)), "govuk-heading-l")
+
+            @itemDetails(AddMoreInformationHelper.itemDetailsKey(page), item, cnCodeInformation)
 
             @govukRadios(
                 RadiosViewModel.yesNo(
                     field = form("value"),
-                    legend = LegendViewModel(HtmlContent(heading)).withCssClass("govuk-!-margin-bottom-0")
-                ).withHint(HintViewModel(HtmlContent(itemDetails(AddMoreInformationHelper.itemDetailsKey(page), item, cnCodeInformation))))
+                    legend = LegendViewModel(Text(AddMoreInformationHelper.headingKey(page))).hidden
+                )
             )
 
             @continueOrExit()
         }
-    }
-
-    @heading = {
-        @h1(messages(AddMoreInformationHelper.headingKey(page), item.itemUniqueReference), None, "govuk-heading-l")
     }
 
 @{

--- a/app/views/ItemMoreInformationView.scala.html
+++ b/app/views/ItemMoreInformationView.scala.html
@@ -50,14 +50,16 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @h2(messages("arc.subHeading", request.arc), "govuk-caption-l")
+        @h1(messages(s"$page.heading", item.itemUniqueReference), Some(messages("arc.subHeading", request.arc)), "govuk-heading-l")
+
+        @itemDetails(s"$page.itemDetails", item, cnCodeInformation)
 
         @govukCharacterCount(CharacterCount(
             id = "more-information",
             name = "more-information",
             maxLength = Some(350),
-            label = largeHeadingWithMarginBottom(messages(s"$page.heading", item.itemUniqueReference)),
-            hint = Some(HintViewModel(HtmlContent(hint))),
+            label = LabelViewModel(messages(s"$page.heading", item.itemUniqueReference)).hidden,
+            hint = Some(HintViewModel(Text(messages(s"$page.hint")))),
             value = form("more-information").value,
             errorMessage = form.errors("more-information") match {
                 case Nil => None
@@ -67,13 +69,6 @@
 
         @continueOrExit()
 
-    }
-}
-
-@hint = {
-    @itemDetails(s"$page.itemDetails", item, cnCodeInformation)
-    @p(classes = "govuk-hint") {
-        @messages(s"$page.hint")
     }
 }
 

--- a/app/views/ItemOtherInformationView.scala.html
+++ b/app/views/ItemOtherInformationView.scala.html
@@ -50,15 +50,17 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @h2(messages("arc.subHeading", request.arc), "govuk-caption-l")
+        @h1(messages(s"$page.heading", item.itemUniqueReference), Some(messages("arc.subHeading", request.arc)), "govuk-heading-l")
+
+        @itemDetails(s"$page.itemDetails", item, cnCodeInformation)
 
         @{
             govukCharacterCount(CharacterCount(
                 id = "more-information",
                 name = "more-information",
                 maxLength = Some(350),
-                label = largeHeadingWithMarginBottom(messages(s"$page.heading", item.itemUniqueReference)),
-                hint = Some(HintViewModel(HtmlContent(hint))),
+                label = LabelViewModel(messages(s"$page.heading", item.itemUniqueReference)).hidden,
+                hint = Some(HintViewModel(Text(messages(s"$page.hint")))),
                 value = form("more-information").value,
                 errorMessage = form.errors("more-information") match {
                     case Nil => None
@@ -69,14 +71,6 @@
 
         @continueOrExit()
 
-    }
-}
-
-
-@hint = {
-    @itemDetails(s"$page.itemDetails", item, cnCodeInformation)
-    @p(classes = "govuk-hint") {
-        @messages(s"$page.hint")
     }
 }
 

--- a/app/views/RefusedAmountView.scala.html
+++ b/app/views/RefusedAmountView.scala.html
@@ -44,6 +44,8 @@
 
         @h1(messages("refusedAmount.heading", messages(s"unitOfMeasure.$unitOfMeasure.long"), idx), Some(messages("arc.subHeading", request.arc)), "govuk-heading-l")
 
+        @itemDetailSection("refusingAnyAmountOfItem.item", item, cnCodeInfo)
+
         @govukInput(
             InputViewModel(
                 field = form("value"),
@@ -53,17 +55,10 @@
             .withSuffix(PrefixOrSuffix(
                 content = Text(messages(s"unitOfMeasure.$unitOfMeasure.short"))
             ))
-            .withHint(HintViewModel(HtmlContent(hint)))
+            .withHint(HintViewModel(Text(messages("refusedAmount.hint"))))
         )
 
         @continueOrExit()
-    }
-}
-
-@hint = {
-    @itemDetailSection("refusingAnyAmountOfItem.item", item, cnCodeInfo)
-    @p(classes = "govuk-hint") {
-        @messages("refusedAmount.hint")
     }
 }
 

--- a/app/views/RefusingAnyAmountOfItemView.scala.html
+++ b/app/views/RefusingAnyAmountOfItemView.scala.html
@@ -26,7 +26,6 @@
     govukRadios: GovukRadios,
     continueOrExit: components.continueOrExit,
     h1: components.h1,
-    h2: components.h2,
     itemDetailSection: itemDetailSection
 )
 
@@ -34,31 +33,25 @@
 
 @layout(pageTitle = title(form, messages("refusingAnyAmountOfItem.title", item.itemUniqueReference))) {
 
-
-
-
-
     @formHelper(action, 'autoComplete -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-@h2((messages("arc.subHeading", request.arc)),"govuk-caption-l")
+        @h1(messages("refusingAnyAmountOfItem.heading", item.itemUniqueReference), Some(messages("arc.subHeading", request.arc)), "govuk-heading-l")
+
+        @itemDetailSection("refusingAnyAmountOfItem.item", item, cnCodeInfo)
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(HtmlContent(heading)).withCssClass("govuk-!-margin-bottom-0")
-            ).withHint(HintViewModel(HtmlContent(itemDetailSection("refusingAnyAmountOfItem.item", item, cnCodeInfo))))
+                legend = LegendViewModel(Text(messages("refusingAnyAmountOfItem.heading", item.itemUniqueReference))).hidden
+            )
         )
 
         @continueOrExit()
     }
-}
-
-@heading = {
-    @h1(messages("refusingAnyAmountOfItem.heading", item.itemUniqueReference), None, "govuk-heading-l")
 }
 
 @{

--- a/app/views/WrongWithItemView.scala.html
+++ b/app/views/WrongWithItemView.scala.html
@@ -27,7 +27,6 @@
         govukCheckboxes: GovukCheckboxes,
         govukButton: GovukButton,
         h1: components.h1,
-        h2: components.h2,
         p: components.p,
         continueOrExit: components.continueOrExit,
         itemDetailSection: components.itemDetailSection
@@ -49,29 +48,20 @@
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> WrongWithMovement.checkboxItems(page).head.value)))
         }
 
-@h2((messages("arc.subHeading", request.arc)),"govuk-caption-l")
+        @h1(messages(s"$page.heading", item.itemUniqueReference), Some(messages("arc.subHeading", request.arc)), "govuk-heading-l")
+
+        @itemDetailSection(s"$page.item", item, cnCodeInfo)
 
         @govukCheckboxes(
             CheckboxesViewModel(
                 form   = form,
                 name   = "value",
-                legend = LegendViewModel(HtmlContent(heading)),
+                legend = LegendViewModel(Text(messages(s"$page.heading", item.itemUniqueReference))).hidden,
                 items  = WrongWithMovement.checkboxItems(page)
-            ).withHint(HintViewModel(HtmlContent(hint)))
+            ).withHint(HintViewModel(Text(messages(s"$page.hint"))))
         )
 
         @continueOrExit()
-    }
-}
-
-@heading = {
-    @h1(messages(s"$page.heading", item.itemUniqueReference), None, "govuk-heading-l")
-}
-
-@hint = {
-    @itemDetailSection(s"$page.item", item, cnCodeInfo)
-    @p(classes = "govuk-hint") {
-        @messages(s"$page.hint")
     }
 }
 


### PR DESCRIPTION
No changes to tests, as views still render similarly. So query selector checks still work as expected. I've stepped through locally and checked visually OK but would be good for someone else to confirm and check I've not missed any pages.