### PR TITLE
[ETFE-2273] - Add visually hidden message to broken seal/item damage choice page

### DIFF
--- a/app/controllers/AddedItemsController.scala
+++ b/app/controllers/AddedItemsController.scala
@@ -49,7 +49,7 @@ class AddedItemsController @Inject()(
                                       getCnCodeInformationService: GetCnCodeInformationService,
                                       checkAnswersItemHelper: CheckAnswersItemHelper,
                                       override val userAnswersService: UserAnswersService,
-                                      override val navigator: Navigator,
+                                      override val navigator: Navigator
                                     )(implicit config: AppConfig) extends BaseNavigationController with AuthActionHelper {
 
   def onPageLoad(ern: String, arc: String): Action[AnyContent] =

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -92,7 +92,7 @@ class CheckYourAnswersController @Inject()(override val messagesApi: MessagesApi
                 routes.SelectItemsController.onPageLoad(ern, arc).url,
                 checkAnswersHelper.summaryList(),
                 formattedAnswers,
-                moreItemsToAdd,
+                moreItemsToAdd
               ))
           }
         }

--- a/app/controllers/ItemShortageOrExcessController.scala
+++ b/app/controllers/ItemShortageOrExcessController.scala
@@ -97,7 +97,7 @@ class ItemShortageOrExcessController @Inject()(override val messagesApi: Message
                       message = "itemShortageOrExcess.amount.error.shortageExceedsTotal",
                       args = Seq(
                         maxAmount(idx, item, isPartiallyRefusingAnAmountOfItem),
-                        request2Messages.messages(s"unitOfMeasure.$unitOfMeasure.short"),
+                        request2Messages.messages(s"unitOfMeasure.$unitOfMeasure.short")
                       )
                     ))
                   Future.successful(BadRequest(renderView(formWithError, ern, arc, idx, mode, unitOfMeasure)))

--- a/app/models/audit/SubmitReportOfReceiptAuditModel.scala
+++ b/app/models/audit/SubmitReportOfReceiptAuditModel.scala
@@ -38,7 +38,7 @@ case class SubmitReportOfReceiptAuditModel(credentialId: String,
       "correlationId" -> correlationId,
       "ern" -> ern,
       "arc" -> submission.arc,
-      "sequenceNumber" -> submission.sequenceNumber,
+      "sequenceNumber" -> submission.sequenceNumber
     ) ++ submission.consigneeTrader.fold(Json.obj())(traderDetail =>
       Json.obj("consigneeTrader"  -> Json.toJson(traderDetail)(TraderModel.auditWrites))) ++
       submission.deliveryPlaceTrader.fold(Json.obj())(traderDetail =>
@@ -46,7 +46,7 @@ case class SubmitReportOfReceiptAuditModel(credentialId: String,
       Json.obj(
         "destinationOffice" -> submission.destinationOffice,
         "dateOfArrival" -> submission.dateOfArrival.toString,
-        "acceptMovement" ->  movement
+        "acceptMovement" -> movement
       ) ++
       individualItemsJsonBlock ++
       Json.obj("otherInformation" -> submission.otherInformation)

--- a/app/viewmodels/ItemDetailsCardHelper.scala
+++ b/app/viewmodels/ItemDetailsCardHelper.scala
@@ -300,7 +300,7 @@ class ItemDetailsCardHelper @Inject()(link: link, list: list, appConfig: AppConf
       quantityRow,
       identityOfCommercialSealRow,
       sealInformationRow,
-      shippingMarksRow,
+      shippingMarksRow
     ).flatten
   }
 }

--- a/app/views/AddItemMoreInformationView.scala.html
+++ b/app/views/AddItemMoreInformationView.scala.html
@@ -55,7 +55,7 @@
             @govukRadios(
                 RadiosViewModel.yesNo(
                     field = form("value"),
-                    legend = LegendViewModel(Text(AddMoreInformationHelper.headingKey(page))).hidden
+                    legend = LegendViewModel(Text(messages(AddMoreInformationHelper.headingKey(page), item.itemUniqueReference))).hidden
                 )
             )
 

--- a/test-utils/fixtures/messages/AddItemDamageInformationMessages.scala
+++ b/test-utils/fixtures/messages/AddItemDamageInformationMessages.scala
@@ -22,11 +22,13 @@ object AddItemDamageInformationMessages {
     override val heading = (i: Int) => s"Do you want to give information about item $i being damaged?"
     override val title = (i: Int) => title(heading(i))
     override val itemDetails = (i: Int) => s"View item $i details"
+    val hiddenLegendText = (i: Int) => s"Do you want to give information about item $i being damaged?"
   }
 
   object Welsh extends AddItemInformationMessagesBase with BaseWelsh {
     override val heading = (i: Int) => s"Do you want to give information about item $i being damaged?"
     override val title = (i: Int) => title(heading(i))
     override val itemDetails = (i: Int) => s"View item $i details"
+    val hiddenLegendText = (i: Int) => s"Do you want to give information about item $i being damaged?"
   }
 }

--- a/test-utils/fixtures/messages/AddItemInformationMessagesBase.scala
+++ b/test-utils/fixtures/messages/AddItemInformationMessagesBase.scala
@@ -21,4 +21,5 @@ trait AddItemInformationMessagesBase {
     val title: Int => String
     val heading: Int => String
     val itemDetails: Int => String
+    val hiddenLegendText: Int => String
 }

--- a/test-utils/fixtures/messages/AddItemSealsInformationMessages.scala
+++ b/test-utils/fixtures/messages/AddItemSealsInformationMessages.scala
@@ -22,11 +22,13 @@ object AddItemSealsInformationMessages {
     override val heading = (i: Int) => s"Do you want to give information about item $i having broken seal(s)?"
     override val title = (i: Int) => title(heading(i))
     override val itemDetails = (i: Int) => s"View item $i details"
+    val hiddenLegendText = (i: Int) => s"Do you want to give information about item $i having broken seal(s)"
   }
 
   object Welsh extends AddItemInformationMessagesBase with BaseWelsh {
     override val heading = (i: Int) => s"Do you want to give information about item $i having broken seal(s)?"
     override val title = (i: Int) => title(heading(i))
     override val itemDetails = (i: Int) => s"View item $i details"
+    val hiddenLegendText = (i: Int) => s"Do you want to give information about item $i having broken seal(s)"
   }
 }

--- a/test/views/AddItemMoreInformationViewSpec.scala
+++ b/test/views/AddItemMoreInformationViewSpec.scala
@@ -30,7 +30,9 @@ class AddItemMoreInformationViewSpec extends ViewSpecBase with ViewBehaviours {
 
   lazy val view = app.injector.instanceOf[AddItemMoreInformationView]
 
-  object Selectors extends BaseSelectors
+  object Selectors extends BaseSelectors {
+    val hiddenLegend = ".govuk-fieldset__legend.govuk-visually-hidden"
+  }
 
   lazy val form = app.injector.instanceOf[AddMoreInformationFormProvider].apply(RemoveItemPage(1))
 
@@ -56,6 +58,7 @@ class AddItemMoreInformationViewSpec extends ViewSpecBase with ViewBehaviours {
             Selectors.detailsSummary(1) -> messagesForLanguage.itemDetails(1),
             Selectors.radioButton(1) -> messagesForLanguage.yes,
             Selectors.radioButton(2) -> messagesForLanguage.no,
+            Selectors.hiddenLegend -> messagesForLanguage.hiddenLegendText(1),
             Selectors.button -> messagesForLanguage.saveAndContinue,
             Selectors.id("save-and-exit") -> messagesForLanguage.savePreviousAnswersAndExit
           ))


### PR DESCRIPTION
Set the visually hidden to the heading of the page:
![image](https://github.com/hmrc/emcs-tfe-report-a-receipt-frontend/assets/53828896/ebe7386e-ebf4-419b-8f82-32604fffb9eb)
![image](https://github.com/hmrc/emcs-tfe-report-a-receipt-frontend/assets/53828896/e01d8d76-883d-4987-819d-f9112394456d)



Also addressed scalastyle errors.