### PR TITLE
DLSC-1775: Only accept GB or XI from trader ID for destination office

### DIFF
--- a/app/models/GBOrXI.scala
+++ b/app/models/GBOrXI.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+sealed trait GBOrXI
+
+object GBOrXI {
+  case object GB extends GBOrXI
+  case object XI extends GBOrXI
+
+  def fromTwoChars(twoChars: String): Option[GBOrXI] =
+    twoChars.toUpperCase match {
+      case "GB" => Some(GB)
+      case "XI" => Some(XI)
+      case _ => None
+    }
+}

--- a/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
+++ b/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
@@ -42,21 +42,21 @@ object SubmitReportOfReceiptModel extends JsonOptionFormatter with ModelConstruc
 
   implicit val fmt: OFormat[SubmitReportOfReceiptModel] = Json.format
 
-  private[models] val DESTINATION_OFFICE_PREFIX_GB = "GB"
-  private[models] val DESTINATION_OFFICE_PREFIX_XI = "XI"
+  private[models] val GB_PREFIX = "GB"
+  private[models] val XI_PREFIX = "XI"
 
   private[models] def destinationOfficePrefix(deliveryPlaceTrader: Option[TraderModel])(implicit userAnswers: UserAnswers): String = {
     if(userAnswers.isNorthernIrelandTrader) {
-      deliveryPlaceTrader.flatMap(_.traderExciseNumber).map(_.take(2)).getOrElse(DESTINATION_OFFICE_PREFIX_XI)
+      deliveryPlaceTrader.flatMap(_.traderId).map(_.take(2)).getOrElse(XI_PREFIX)
     } else {
-      DESTINATION_OFFICE_PREFIX_GB
+      GB_PREFIX
     }
   }
 
   private[models] def consigneeTraderDetails(movementDetails: GetMovementResponse)(implicit userAnswers: UserAnswers): Option[TraderModel] = {
     (movementDetails.destinationType, movementDetails.consigneeTrader) match {
       case (TemporaryRegisteredConsignee, Some(consignee: TraderModel)) =>
-        Some(consignee.copy(traderExciseNumber = Some(userAnswers.ern)))
+        Some(consignee.copy(traderId = Some(userAnswers.ern)))
       case (destinationType, Some(consignee: TraderModel)) if (destinationType != Export) =>
         Some(consignee.copy(eoriNumber = None))
       case (_, consignee) =>

--- a/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
+++ b/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
@@ -18,9 +18,10 @@ package models.submitReportOfReceipt
 
 import config.AppConfig
 import models.DestinationType.{Export, TemporaryRegisteredConsignee}
-import models.{AcceptMovement, DestinationType, UserAnswers}
+import models.GBOrXI.{GB, XI, fromTwoChars}
 import models.WrongWithMovement._
 import models.response.emcsTfe.GetMovementResponse
+import models.{AcceptMovement, DestinationType, GBOrXI, UserAnswers}
 import pages.{AcceptMovementPage, DateOfArrivalPage, MoreInformationPage}
 import play.api.libs.json.{Json, OFormat}
 import utils.{JsonOptionFormatter, ModelConstructorHelpers}
@@ -42,20 +43,26 @@ object SubmitReportOfReceiptModel extends JsonOptionFormatter with ModelConstruc
 
   implicit val fmt: OFormat[SubmitReportOfReceiptModel] = Json.format
 
-  private[models] val GB_PREFIX = "GB"
-  private[models] val XI_PREFIX = "XI"
-  private val VALID_PREFIXES = Set(GB_PREFIX, XI_PREFIX)
+  private[models] def destinationOfficePrefix(maybeDeliveryPlaceTrader: Option[TraderModel])(implicit userAnswers: UserAnswers): GBOrXI = {
+    val gbOrXiFromUserAnswers = if (userAnswers.isNorthernIrelandTrader) XI else GB
 
-  private[models] def destinationOfficePrefix(deliveryPlaceTrader: Option[TraderModel])(implicit userAnswers: UserAnswers): String = {
-    if(userAnswers.isNorthernIrelandTrader) {
-      deliveryPlaceTrader.flatMap(_.traderId).flatMap(
-        traderId => {
-          val first2Chars = traderId.take(2)
-          Option.when(VALID_PREFIXES.contains(first2Chars))(first2Chars)
-        }
-      ).getOrElse(XI_PREFIX)
-    } else {
-      GB_PREFIX
+    // If this Option is Some, it's value can only be GB or XI.
+    // We allow for the possibility that it might be neither (None) because the DeliveryPlaceTrader's trader ID can be anything when the DestinationType
+    // is not a warehouse.
+    // Even though it seems most EMCS systems in the UK and EU use ERNs for trader ID regardless of DestinationType,
+    // we have seen non-ERNs in use in the real world - see DLSC-1775 for an example.
+    val maybeGBOrXIFromDeliveryPlaceTraderPrefix = for {
+      deliveryPlaceTrader <- maybeDeliveryPlaceTrader
+      traderId <- deliveryPlaceTrader.traderId
+      gbOrXi <- fromTwoChars(traderId.take(2))
+    } yield gbOrXi
+
+    // If the ERN from the user's answers starts with XI, and the DeliveryPlaceTrader's trader ID starts with GB or XI, we use the latter.
+    // Otherwise, we use the GB or XI from the user's answers.
+    // We've checked with Core that this behaviour is correct.
+    (gbOrXiFromUserAnswers, maybeGBOrXIFromDeliveryPlaceTraderPrefix) match {
+      case (XI, Some(gbOrXiFromPrefix)) => gbOrXiFromPrefix
+      case _ => gbOrXiFromUserAnswers
     }
   }
 
@@ -69,6 +76,7 @@ object SubmitReportOfReceiptModel extends JsonOptionFormatter with ModelConstruc
         consignee
     }
   }
+
   def apply(movementDetails: GetMovementResponse)(implicit userAnswers: UserAnswers, appConfig: AppConfig): SubmitReportOfReceiptModel = {
 
     SubmitReportOfReceiptModel(
@@ -77,7 +85,7 @@ object SubmitReportOfReceiptModel extends JsonOptionFormatter with ModelConstruc
       destinationType = movementDetails.destinationType,
       consigneeTrader = consigneeTraderDetails(movementDetails),
       deliveryPlaceTrader = movementDetails.deliveryPlaceTrader,
-      destinationOffice = destinationOfficePrefix(movementDetails.deliveryPlaceTrader) + appConfig.destinationOfficeSuffix,
+      destinationOffice = s"${destinationOfficePrefix(movementDetails.deliveryPlaceTrader)}${appConfig.destinationOfficeSuffix}",
       dateOfArrival = mandatoryPage(DateOfArrivalPage),
       acceptMovement = mandatoryPage(AcceptMovementPage),
       individualItems = ReceiptedItemsModel(movementDetails),

--- a/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
+++ b/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
@@ -44,10 +44,16 @@ object SubmitReportOfReceiptModel extends JsonOptionFormatter with ModelConstruc
 
   private[models] val GB_PREFIX = "GB"
   private[models] val XI_PREFIX = "XI"
+  private val VALID_PREFIXES = Set(GB_PREFIX, XI_PREFIX)
 
   private[models] def destinationOfficePrefix(deliveryPlaceTrader: Option[TraderModel])(implicit userAnswers: UserAnswers): String = {
     if(userAnswers.isNorthernIrelandTrader) {
-      deliveryPlaceTrader.flatMap(_.traderId).map(_.take(2)).getOrElse(XI_PREFIX)
+      deliveryPlaceTrader.flatMap(_.traderId).flatMap(
+        traderId => {
+          val first2Chars = traderId.take(2)
+          Option.when(VALID_PREFIXES.contains(first2Chars))(first2Chars)
+        }
+      ).getOrElse(XI_PREFIX)
     } else {
       GB_PREFIX
     }

--- a/app/models/submitReportOfReceipt/TraderModel.scala
+++ b/app/models/submitReportOfReceipt/TraderModel.scala
@@ -19,7 +19,7 @@ package models.submitReportOfReceipt
 import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json.{Format, Json, Writes}
 
-case class TraderModel(traderExciseNumber: Option[String],
+case class TraderModel(traderId: Option[String],
                        traderName: Option[String],
                        address: Option[AddressModel],
                        eoriNumber: Option[String])
@@ -29,7 +29,7 @@ object TraderModel {
 
   val auditWrites = Writes[TraderModel] { model =>
     Json.obj(Seq[Option[(String, JsValueWrapper)]](
-      model.traderExciseNumber.map("traderId" -> _),
+      model.traderId.map("traderId" -> _),
       model.traderName.map("traderName" -> _),
       model.address.map("address" -> _),
       model.eoriNumber.map("eoriNumber" -> _)

--- a/test-utils/fixtures/TraderModelFixtures.scala
+++ b/test-utils/fixtures/TraderModelFixtures.scala
@@ -21,14 +21,14 @@ import models.submitReportOfReceipt.TraderModel
 trait TraderModelFixtures extends BaseFixtures with AddressModelFixtures {
 
   val maxTraderModel = TraderModel(
-    traderExciseNumber = Some("id"),
+    traderId = Some("id"),
     traderName = Some("name"),
     address = Some(maxAddressModel),
     eoriNumber = Some("eori")
   )
 
   val minTraderModel = TraderModel(
-    traderExciseNumber = None,
+    traderId = None,
     traderName = None,
     address = None,
     eoriNumber = None

--- a/test-utils/fixtures/audit/SubmitReportOfReceiptAuditModelFixture.scala
+++ b/test-utils/fixtures/audit/SubmitReportOfReceiptAuditModelFixture.scala
@@ -39,13 +39,13 @@ object SubmitReportOfReceiptAuditModelFixture {
         sequenceNumber = 1,
         destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
-          traderExciseNumber = Some("id"),
+          traderId = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = Some("eori")
         )),
         deliveryPlaceTrader = Some(TraderModel(
-          traderExciseNumber = Some("id"),
+          traderId = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = None
@@ -69,13 +69,13 @@ object SubmitReportOfReceiptAuditModelFixture {
         sequenceNumber = 1,
         destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
-          traderExciseNumber = Some("id"),
+          traderId = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = Some("eori")
         )),
         deliveryPlaceTrader = Some(TraderModel(
-          traderExciseNumber = Some("id"),
+          traderId = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = None
@@ -129,13 +129,13 @@ object SubmitReportOfReceiptAuditModelFixture {
       sequenceNumber = 1,
         destinationType = DirectDelivery,
       consigneeTrader = Some(TraderModel(
-        traderExciseNumber = Some("id"),
+        traderId = Some("id"),
         traderName = Some("name"),
         address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
         eoriNumber = Some("eori")
       )),
       deliveryPlaceTrader = Some(TraderModel(
-        traderExciseNumber = Some("id"),
+        traderId = Some("id"),
         traderName = Some("name"),
         address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
         eoriNumber = None
@@ -189,13 +189,13 @@ object SubmitReportOfReceiptAuditModelFixture {
         sequenceNumber = 1,
         destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
-          traderExciseNumber = Some("id"),
+          traderId = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = Some("eori")
         )),
         deliveryPlaceTrader = Some(TraderModel(
-          traderExciseNumber = Some("id"),
+          traderId = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = None

--- a/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
+++ b/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
@@ -21,11 +21,11 @@ import config.AppConfig
 import fixtures.{GetMovementResponseFixtures, SubmitReportOfReceiptFixtures, TraderModelFixtures}
 import models.AcceptMovement.{PartiallyRefused, Refused, Satisfactory, Unsatisfactory}
 import models.DestinationType.{Export, TaxWarehouse, TemporaryRegisteredConsignee}
+import models.GBOrXI.{GB, XI}
 import models.HowGiveInformation.{IndividualItem, TheWholeMovement}
 import models.WrongWithMovement.{BrokenSeals, Damaged, Excess, Other, Shortage, ShortageOrExcess}
 import models.response.MissingMandatoryPage
 import models.response.emcsTfe.GetMovementResponse
-import models.submitReportOfReceipt.SubmitReportOfReceiptModel.{GB_PREFIX, XI_PREFIX}
 import models.{DestinationType, ItemShortageOrExcessModel, WrongWithMovement}
 import org.scalamock.scalatest.MockFactory
 import pages._
@@ -411,41 +411,41 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
       val GB_ID = "GB123123123"
       val XI_ID = "XI123123123"
 
-      s"must return $GB_PREFIX" - {
-        s"when logged in user's ERN starts with $GB_PREFIX" in {
+      s"must return $GB" - {
+        s"when logged in user's ERN starts with $GB" in {
           val userAnswers = emptyUserAnswers.copy(ern = GB_ID)
-          SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe GB_PREFIX
+          SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe GB
         }
-        s"when logged in user's ERN starts with $XI_PREFIX and deliveryPlaceTrader's ID is an ERN starting with $GB_PREFIX" in {
+        s"when logged in user's ERN starts with $XI and deliveryPlaceTrader's ID is an ERN starting with $GB" in {
           val userAnswers = emptyUserAnswers.copy(ern = XI_ID)
           SubmitReportOfReceiptModel.destinationOfficePrefix(
             Some(TraderModel(traderId = Some("GB00000000206"), None, None, None))
-          )(userAnswers) mustBe GB_PREFIX
+          )(userAnswers) mustBe GB
         }
-        s"when logged in user's ERN doesn't start with $GB_PREFIX or $XI_PREFIX (default case)" in {
+        s"when logged in user's ERN doesn't start with $GB or $XI (default case)" in {
           val userAnswers = emptyUserAnswers.copy(ern = testErn)
           SubmitReportOfReceiptModel.destinationOfficePrefix(
             Some(TraderModel(traderId = Some("a free-form trader ID"), None, None, None))
-          )(userAnswers) mustBe GB_PREFIX
+          )(userAnswers) mustBe GB
         }
       }
-      s"must return $XI_PREFIX" - {
-        s"when logged in user's ERN starts with $XI_PREFIX and deliveryPlaceTrader's ID is an ERN starting with $XI_PREFIX" in {
+      s"must return $XI" - {
+        s"when logged in user's ERN starts with $XI and deliveryPlaceTrader's ID is an ERN starting with $XI" in {
           val userAnswers = emptyUserAnswers.copy(ern = XI_ID)
           SubmitReportOfReceiptModel.destinationOfficePrefix(
             Some(TraderModel(traderId = Some("XI00000000206"), None, None, None))
-          )(userAnswers) mustBe XI_PREFIX
+          )(userAnswers) mustBe XI
         }
-        s"when logged in user's ERN starts with $XI_PREFIX and no deliveryPlaceTrader is provided" in {
+        s"when logged in user's ERN starts with $XI and no deliveryPlaceTrader is provided" in {
           val userAnswers = emptyUserAnswers.copy(ern = XI_ID)
-          SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe XI_PREFIX
+          SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe XI
         }
 
-        s"when logged in user's ERN starts with $XI_PREFIX and deliveryPlaceTrader's ID starts with neither $GB_PREFIX nor $XI_PREFIX" in {
+        s"when logged in user's ERN starts with $XI and deliveryPlaceTrader's ID starts with neither $GB nor $XI" in {
           val userAnswers = emptyUserAnswers.copy(ern = XI_ID)
           SubmitReportOfReceiptModel.destinationOfficePrefix(
             Some(TraderModel(traderId = Some("a free-form trader ID"), None, None, None))
-          )(userAnswers) mustBe XI_PREFIX
+          )(userAnswers) mustBe XI
         }
       }
     }

--- a/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
+++ b/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
@@ -441,6 +441,12 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
           SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe XI_PREFIX
         }
 
+        s"when logged in user's ERN starts with $XI_PREFIX and deliveryPlaceTrader's ID starts with neither $GB_PREFIX nor $XI_PREFIX" in {
+          val userAnswers = emptyUserAnswers.copy(ern = XI_ID)
+          SubmitReportOfReceiptModel.destinationOfficePrefix(
+            Some(TraderModel(traderId = Some("a free-form trader ID"), None, None, None))
+          )(userAnswers) mustBe XI_PREFIX
+        }
       }
     }
 

--- a/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
+++ b/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
@@ -25,7 +25,7 @@ import models.HowGiveInformation.{IndividualItem, TheWholeMovement}
 import models.WrongWithMovement.{BrokenSeals, Damaged, Excess, Other, Shortage, ShortageOrExcess}
 import models.response.MissingMandatoryPage
 import models.response.emcsTfe.GetMovementResponse
-import models.submitReportOfReceipt.SubmitReportOfReceiptModel.{DESTINATION_OFFICE_PREFIX_GB, DESTINATION_OFFICE_PREFIX_XI}
+import models.submitReportOfReceipt.SubmitReportOfReceiptModel.{GB_PREFIX, XI_PREFIX}
 import models.{DestinationType, ItemShortageOrExcessModel, WrongWithMovement}
 import org.scalamock.scalatest.MockFactory
 import pages._
@@ -264,7 +264,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               .set(ItemSealsInformationPage(item2.itemUniqueReference), Some("BrokenSeals"))
 
 
-          val newGetMovementModel = getMovementResponseModel.copy(deliveryPlaceTrader = Some(TraderModel(traderExciseNumber = Some("GB00000000206"), None, None, None)))
+          val newGetMovementModel = getMovementResponseModel.copy(deliveryPlaceTrader = Some(TraderModel(traderId = Some("GB00000000206"), None, None, None)))
           val submission = SubmitReportOfReceiptModel(newGetMovementModel)(userAnswers, mockAppConfig)
 
           submission mustBe SubmitReportOfReceiptModel(
@@ -312,7 +312,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               .set(ItemSealsInformationPage(item2.itemUniqueReference), Some("BrokenSeals"))
 
 
-          val newGetMovementModel = getMovementResponseModel.copy(deliveryPlaceTrader = Some(TraderModel(traderExciseNumber = Some("XI00000000206"), None, None, None)))
+          val newGetMovementModel = getMovementResponseModel.copy(deliveryPlaceTrader = Some(TraderModel(traderId = Some("XI00000000206"), None, None, None)))
           val submission = SubmitReportOfReceiptModel(newGetMovementModel)(userAnswers, mockAppConfig)
 
           submission mustBe SubmitReportOfReceiptModel(
@@ -411,28 +411,34 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
       val GB_ID = "GB123123123"
       val XI_ID = "XI123123123"
 
-      s"must return $DESTINATION_OFFICE_PREFIX_GB" - {
-        s"when logged in user ERN starts with $DESTINATION_OFFICE_PREFIX_GB" in {
+      s"must return $GB_PREFIX" - {
+        s"when logged in user's ERN starts with $GB_PREFIX" in {
           val userAnswers = emptyUserAnswers.copy(ern = GB_ID)
-          SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe DESTINATION_OFFICE_PREFIX_GB
+          SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe GB_PREFIX
         }
-        s"when logged in user ERN starts with $DESTINATION_OFFICE_PREFIX_XI and deliveryPlaceTraders ERN starts with $DESTINATION_OFFICE_PREFIX_GB" in {
+        s"when logged in user's ERN starts with $XI_PREFIX and deliveryPlaceTrader's ID is an ERN starting with $GB_PREFIX" in {
           val userAnswers = emptyUserAnswers.copy(ern = XI_ID)
-          SubmitReportOfReceiptModel.destinationOfficePrefix(Some(TraderModel(traderExciseNumber = Some("GB00000000206"), None, None, None)))(userAnswers) mustBe DESTINATION_OFFICE_PREFIX_GB
+          SubmitReportOfReceiptModel.destinationOfficePrefix(
+            Some(TraderModel(traderId = Some("GB00000000206"), None, None, None))
+          )(userAnswers) mustBe GB_PREFIX
         }
-        s"when logged in user ERN doesn't start with $DESTINATION_OFFICE_PREFIX_GB or $DESTINATION_OFFICE_PREFIX_XI (default case)" in {
+        s"when logged in user's ERN doesn't start with $GB_PREFIX or $XI_PREFIX (default case)" in {
           val userAnswers = emptyUserAnswers.copy(ern = testErn)
-          SubmitReportOfReceiptModel.destinationOfficePrefix(Some(TraderModel(traderExciseNumber = Some("TR00000000206"), None, None, None)))(userAnswers) mustBe DESTINATION_OFFICE_PREFIX_GB
+          SubmitReportOfReceiptModel.destinationOfficePrefix(
+            Some(TraderModel(traderId = Some("a free-form trader ID"), None, None, None))
+          )(userAnswers) mustBe GB_PREFIX
         }
       }
-      s"must return $DESTINATION_OFFICE_PREFIX_XI" - {
-        s"when logged in user ERN starts with $DESTINATION_OFFICE_PREFIX_XI and deliveryPlaceTrader ERN starts with $DESTINATION_OFFICE_PREFIX_XI" in {
+      s"must return $XI_PREFIX" - {
+        s"when logged in user's ERN starts with $XI_PREFIX and deliveryPlaceTrader's ID is an ERN starting with $XI_PREFIX" in {
           val userAnswers = emptyUserAnswers.copy(ern = XI_ID)
-          SubmitReportOfReceiptModel.destinationOfficePrefix(Some(TraderModel(traderExciseNumber = Some("XI00000000206"), None, None, None)))(userAnswers) mustBe DESTINATION_OFFICE_PREFIX_XI
+          SubmitReportOfReceiptModel.destinationOfficePrefix(
+            Some(TraderModel(traderId = Some("XI00000000206"), None, None, None))
+          )(userAnswers) mustBe XI_PREFIX
         }
-        s"when logged in user ERN starts with $DESTINATION_OFFICE_PREFIX_XI and no deliveryPlaceTrader is provided" in {
+        s"when logged in user's ERN starts with $XI_PREFIX and no deliveryPlaceTrader is provided" in {
           val userAnswers = emptyUserAnswers.copy(ern = XI_ID)
-          SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe DESTINATION_OFFICE_PREFIX_XI
+          SubmitReportOfReceiptModel.destinationOfficePrefix(None)(userAnswers) mustBe XI_PREFIX
         }
 
       }
@@ -447,7 +453,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
             destinationType = TemporaryRegisteredConsignee,
             consigneeTrader = Some(
               TraderModel(
-                traderExciseNumber = Some("TCA1234567890"),
+                traderId = Some("TCA1234567890"),
                 traderName = None,
                 address = None,
                 eoriNumber = None
@@ -468,7 +474,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               destinationType = destinationType,
               consigneeTrader = Some(
                 TraderModel(
-                  traderExciseNumber = Some("GB1234567890"),
+                  traderId = Some("GB1234567890"),
                   traderName = None,
                   address = None,
                   eoriNumber = None
@@ -479,7 +485,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               destinationType = Export,
                 consigneeTrader = Some(
                   TraderModel(
-                    traderExciseNumber = Some("GB1234567890"),
+                    traderId = Some("GB1234567890"),
                     traderName = None,
                     address = None,
                     eoriNumber = Some("GB1234567890")
@@ -490,7 +496,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               destinationType = TaxWarehouse,
                   consigneeTrader = Some(
                     TraderModel(
-                      traderExciseNumber = Some("GB1234567890"),
+                      traderId = Some("GB1234567890"),
                       traderName = None,
                       address = None,
                       eoriNumber = Some("GB1234567890")
@@ -500,7 +506,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
             val expectedmovement2: GetMovementResponse = getMovementResponseModel.copy(
               consigneeTrader = Some(
                 TraderModel(
-                  traderExciseNumber = Some("GB1234567890"),
+                  traderId = Some("GB1234567890"),
                   traderName = None,
                   address = None,
                   eoriNumber = None

--- a/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
+++ b/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
@@ -422,8 +422,8 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
             Some(TraderModel(traderId = Some("GB00000000206"), None, None, None))
           )(userAnswers) mustBe GB
         }
-        s"when logged in user's ERN doesn't start with $GB or $XI (default case)" in {
-          val userAnswers = emptyUserAnswers.copy(ern = testErn)
+        s"when logged in user's ERN starts with $GB and deliveryPlaceTrader's ID starts with neither $GB nor $XI" in {
+          val userAnswers = emptyUserAnswers.copy(ern = GB_ID)
           SubmitReportOfReceiptModel.destinationOfficePrefix(
             Some(TraderModel(traderId = Some("a free-form trader ID"), None, None, None))
           )(userAnswers) mustBe GB


### PR DESCRIPTION
This work was originally done on branch CS-8629 named after the old Jira ticket number scheme. Because the PR has been around for a while while we figure out what to do, I've copied the old branch and renamed it to use the new Jira ticket number DLSC-1775