### PR TITLE
DLSC-1775: Rename traderId back to traderExciseNumber

### DIFF
--- a/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
+++ b/app/models/submitReportOfReceipt/SubmitReportOfReceiptModel.scala
@@ -53,7 +53,7 @@ object SubmitReportOfReceiptModel extends JsonOptionFormatter with ModelConstruc
     // we have seen non-ERNs in use in the real world - see DLSC-1775 for an example.
     val maybeGBOrXIFromDeliveryPlaceTraderPrefix = for {
       deliveryPlaceTrader <- maybeDeliveryPlaceTrader
-      traderId <- deliveryPlaceTrader.traderId
+      traderId <- deliveryPlaceTrader.traderExciseNumber
       gbOrXi <- fromTwoChars(traderId.take(2))
     } yield gbOrXi
 
@@ -69,7 +69,7 @@ object SubmitReportOfReceiptModel extends JsonOptionFormatter with ModelConstruc
   private[models] def consigneeTraderDetails(movementDetails: GetMovementResponse)(implicit userAnswers: UserAnswers): Option[TraderModel] = {
     (movementDetails.destinationType, movementDetails.consigneeTrader) match {
       case (TemporaryRegisteredConsignee, Some(consignee: TraderModel)) =>
-        Some(consignee.copy(traderId = Some(userAnswers.ern)))
+        Some(consignee.copy(traderExciseNumber = Some(userAnswers.ern)))
       case (destinationType, Some(consignee: TraderModel)) if (destinationType != Export) =>
         Some(consignee.copy(eoriNumber = None))
       case (_, consignee) =>

--- a/app/models/submitReportOfReceipt/TraderModel.scala
+++ b/app/models/submitReportOfReceipt/TraderModel.scala
@@ -19,7 +19,11 @@ package models.submitReportOfReceipt
 import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json.{Format, Json, Writes}
 
-case class TraderModel(traderId: Option[String],
+// Strictly speaking, traderExciseNumber should be called traderId here because the trader type is DeliveryPlaceTrader.
+// This is also the case when the trader type is ConsigneeTrader or TransportTrader.
+// In these cases the values for this field do not have to be ERNs.
+// Unfortunately, emcs-tfe expects all TraderModels to use the same field name (traderExciseNumber)
+case class TraderModel(traderExciseNumber: Option[String],
                        traderName: Option[String],
                        address: Option[AddressModel],
                        eoriNumber: Option[String])
@@ -29,7 +33,7 @@ object TraderModel {
 
   val auditWrites = Writes[TraderModel] { model =>
     Json.obj(Seq[Option[(String, JsValueWrapper)]](
-      model.traderId.map("traderId" -> _),
+      model.traderExciseNumber.map("traderId" -> _),
       model.traderName.map("traderName" -> _),
       model.address.map("address" -> _),
       model.eoriNumber.map("eoriNumber" -> _)

--- a/test-utils/fixtures/TraderModelFixtures.scala
+++ b/test-utils/fixtures/TraderModelFixtures.scala
@@ -21,14 +21,14 @@ import models.submitReportOfReceipt.TraderModel
 trait TraderModelFixtures extends BaseFixtures with AddressModelFixtures {
 
   val maxTraderModel = TraderModel(
-    traderId = Some("id"),
+    traderExciseNumber = Some("id"),
     traderName = Some("name"),
     address = Some(maxAddressModel),
     eoriNumber = Some("eori")
   )
 
   val minTraderModel = TraderModel(
-    traderId = None,
+    traderExciseNumber = None,
     traderName = None,
     address = None,
     eoriNumber = None

--- a/test-utils/fixtures/audit/SubmitReportOfReceiptAuditModelFixture.scala
+++ b/test-utils/fixtures/audit/SubmitReportOfReceiptAuditModelFixture.scala
@@ -39,13 +39,13 @@ object SubmitReportOfReceiptAuditModelFixture {
         sequenceNumber = 1,
         destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
-          traderId = Some("id"),
+          traderExciseNumber = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = Some("eori")
         )),
         deliveryPlaceTrader = Some(TraderModel(
-          traderId = Some("id"),
+          traderExciseNumber = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = None
@@ -69,13 +69,13 @@ object SubmitReportOfReceiptAuditModelFixture {
         sequenceNumber = 1,
         destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
-          traderId = Some("id"),
+          traderExciseNumber = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = Some("eori")
         )),
         deliveryPlaceTrader = Some(TraderModel(
-          traderId = Some("id"),
+          traderExciseNumber = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = None
@@ -129,13 +129,13 @@ object SubmitReportOfReceiptAuditModelFixture {
       sequenceNumber = 1,
         destinationType = DirectDelivery,
       consigneeTrader = Some(TraderModel(
-        traderId = Some("id"),
+        traderExciseNumber = Some("id"),
         traderName = Some("name"),
         address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
         eoriNumber = Some("eori")
       )),
       deliveryPlaceTrader = Some(TraderModel(
-        traderId = Some("id"),
+        traderExciseNumber = Some("id"),
         traderName = Some("name"),
         address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
         eoriNumber = None
@@ -189,13 +189,13 @@ object SubmitReportOfReceiptAuditModelFixture {
         sequenceNumber = 1,
         destinationType = DirectDelivery,
         consigneeTrader = Some(TraderModel(
-          traderId = Some("id"),
+          traderExciseNumber = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = Some("eori")
         )),
         deliveryPlaceTrader = Some(TraderModel(
-          traderId = Some("id"),
+          traderExciseNumber = Some("id"),
           traderName = Some("name"),
           address = Some(AddressModel(Some("number"), Some("street"), Some("postcode"),Some("city"))),
           eoriNumber = None

--- a/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
+++ b/test/models/submitReportOfReceipt/SubmitReportOfReceiptModelSpec.scala
@@ -264,7 +264,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               .set(ItemSealsInformationPage(item2.itemUniqueReference), Some("BrokenSeals"))
 
 
-          val newGetMovementModel = getMovementResponseModel.copy(deliveryPlaceTrader = Some(TraderModel(traderId = Some("GB00000000206"), None, None, None)))
+          val newGetMovementModel = getMovementResponseModel.copy(deliveryPlaceTrader = Some(TraderModel(traderExciseNumber = Some("GB00000000206"), None, None, None)))
           val submission = SubmitReportOfReceiptModel(newGetMovementModel)(userAnswers, mockAppConfig)
 
           submission mustBe SubmitReportOfReceiptModel(
@@ -312,7 +312,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               .set(ItemSealsInformationPage(item2.itemUniqueReference), Some("BrokenSeals"))
 
 
-          val newGetMovementModel = getMovementResponseModel.copy(deliveryPlaceTrader = Some(TraderModel(traderId = Some("XI00000000206"), None, None, None)))
+          val newGetMovementModel = getMovementResponseModel.copy(deliveryPlaceTrader = Some(TraderModel(traderExciseNumber = Some("XI00000000206"), None, None, None)))
           val submission = SubmitReportOfReceiptModel(newGetMovementModel)(userAnswers, mockAppConfig)
 
           submission mustBe SubmitReportOfReceiptModel(
@@ -419,22 +419,22 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
         }
         s"when no traderId is provided" in {
           SubmitReportOfReceiptModel.destinationOfficePrefix(
-            Some(TraderModel(traderId = None, None, None, None))
+            Some(TraderModel(traderExciseNumber = None, None, None, None))
           )(userAnswers) mustBe GB
         }
         s"when deliveryPlaceTrader's ID starts with $GB" in {
           SubmitReportOfReceiptModel.destinationOfficePrefix(
-            Some(TraderModel(traderId = Some("GB00000000206"), None, None, None))
+            Some(TraderModel(traderExciseNumber = Some("GB00000000206"), None, None, None))
           )(userAnswers) mustBe GB
         }
         s"when deliveryPlaceTrader's ID starts with $XI" in {
           SubmitReportOfReceiptModel.destinationOfficePrefix(
-            Some(TraderModel(traderId = Some("XI00000000206"), None, None, None))
+            Some(TraderModel(traderExciseNumber = Some("XI00000000206"), None, None, None))
           )(userAnswers) mustBe GB
         }
         s"when deliveryPlaceTrader's ID starts with neither $GB nor $XI" in {
           SubmitReportOfReceiptModel.destinationOfficePrefix(
-            Some(TraderModel(traderId = Some("a free-form trader ID"), None, None, None))
+            Some(TraderModel(traderExciseNumber = Some("a free-form trader ID"), None, None, None))
           )(userAnswers) mustBe GB
         }
       }
@@ -444,12 +444,12 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
 
         s"when deliveryPlaceTrader's ID is an ERN starting with $GB, it should return $GB" in {
           SubmitReportOfReceiptModel.destinationOfficePrefix(
-            Some(TraderModel(traderId = Some("GB00000000206"), None, None, None))
+            Some(TraderModel(traderExciseNumber = Some("GB00000000206"), None, None, None))
           )(userAnswers) mustBe GB
         }
         s"when deliveryPlaceTrader's ID is an ERN starting with $XI, it should return $XI" in {
           SubmitReportOfReceiptModel.destinationOfficePrefix(
-            Some(TraderModel(traderId = Some("XI00000000206"), None, None, None))
+            Some(TraderModel(traderExciseNumber = Some("XI00000000206"), None, None, None))
           )(userAnswers) mustBe XI
         }
         s"when no deliveryPlaceTrader is provided, it should return $XI" in {
@@ -457,12 +457,12 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
         }
         s"when no traderId is provided, it should return $XI" in {
           SubmitReportOfReceiptModel.destinationOfficePrefix(
-            Some(TraderModel(traderId = None, None, None, None))
+            Some(TraderModel(traderExciseNumber = None, None, None, None))
           )(userAnswers) mustBe XI
         }
         s"when deliveryPlaceTrader's ID starts with neither $GB nor $XI, it should return $XI" in {
           SubmitReportOfReceiptModel.destinationOfficePrefix(
-            Some(TraderModel(traderId = Some("a free-form trader ID"), None, None, None))
+            Some(TraderModel(traderExciseNumber = Some("a free-form trader ID"), None, None, None))
           )(userAnswers) mustBe XI
         }
       }
@@ -477,7 +477,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
             destinationType = TemporaryRegisteredConsignee,
             consigneeTrader = Some(
               TraderModel(
-                traderId = Some("TCA1234567890"),
+                traderExciseNumber = Some("TCA1234567890"),
                 traderName = None,
                 address = None,
                 eoriNumber = None
@@ -498,7 +498,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               destinationType = destinationType,
               consigneeTrader = Some(
                 TraderModel(
-                  traderId = Some("GB1234567890"),
+                  traderExciseNumber = Some("GB1234567890"),
                   traderName = None,
                   address = None,
                   eoriNumber = None
@@ -509,7 +509,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               destinationType = Export,
                 consigneeTrader = Some(
                   TraderModel(
-                    traderId = Some("GB1234567890"),
+                    traderExciseNumber = Some("GB1234567890"),
                     traderName = None,
                     address = None,
                     eoriNumber = Some("GB1234567890")
@@ -520,7 +520,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
               destinationType = TaxWarehouse,
                   consigneeTrader = Some(
                     TraderModel(
-                      traderId = Some("GB1234567890"),
+                      traderExciseNumber = Some("GB1234567890"),
                       traderName = None,
                       address = None,
                       eoriNumber = Some("GB1234567890")
@@ -530,7 +530,7 @@ class SubmitReportOfReceiptModelSpec extends SpecBase
             val expectedmovement2: GetMovementResponse = getMovementResponseModel.copy(
               consigneeTrader = Some(
                 TraderModel(
-                  traderId = Some("GB1234567890"),
+                  traderExciseNumber = Some("GB1234567890"),
                   traderName = None,
                   address = None,
                   eoriNumber = None


### PR DESCRIPTION
Strictly speaking, the field should be called traderId, which is the name in the EMCS spec and the XML (because the values for this field do not have to be ERNs). Unfortunately, emcs-tfe expects all TraderModels to use the same field name (traderExciseNumber)